### PR TITLE
Fix rainbow text font + update decomp

### DIFF
--- a/src/code_80091750.c
+++ b/src/code_80091750.c
@@ -938,6 +938,12 @@ s32 D_800E84A0[] = {
     0x13, 0x13, 0x13, 0x13, 0x13, 0x13, 0x13, 0x13,
 };
 
+Vtx* D_800E84C0[] = {
+    D_02007BB8,
+    D_02007CD8,
+    D_02007DF8,
+};
+
 #ifndef AVOID_UB
 Gfx* D_800E84CC[] = {
     D_02007838, D_02007858, D_02007878, D_02007898, D_020078B8, D_020078D8, D_020078F8, D_02007918,
@@ -1351,7 +1357,6 @@ void func_80092258(void) {
     }
 }
 
-//! @bug vtx overflow from idx + 36 in this func
 void func_80092290(s32 arg0, s32* arg1, s32* arg2) {
     s32 temp_v1;
     s32 i;
@@ -1363,16 +1368,6 @@ void func_80092290(s32 arg0, s32* arg1, s32* arg2) {
     s32 temp_t0;
     s32 a, b, c, d;
     Vtx* vtx;
-
-    Vtx* v1 = (Vtx*) LOAD_ASSET(D_02007BB8);
-    Vtx *v2 = (Vtx *) LOAD_ASSET(D_02007CD8);
-    Vtx *v3 = (Vtx *) LOAD_ASSET(D_02007DF8);
-
-    Vtx* D_800E84C0[] = {
-        &v1[0],
-        &v2[0],
-        &v3[0],
-    };
 
     if ((arg0 < 4) || (arg0 >= 6)) {
         return;
@@ -1387,21 +1382,10 @@ void func_80092290(s32 arg0, s32* arg1, s32* arg2) {
     }
 
     for (i = 0; i < 3; i++) {
-        if (i == 0) {
-            vtx = (Vtx*) &v1[0];
-        } else if (i == 1) {
-            vtx = (Vtx*) &v2[0];
-        } else if (i == 2) {
-            vtx = (Vtx*) &v3[0];
-        }
-        // vtx = (Vtx *) segmented_to_virtual_dupe_2(&v1[0]);
+        vtx = (Vtx*) LOAD_ASSET(D_800E84C0[i]);
 
         temp_v1 = (*arg1 * 2) + 2;
 
-        //! @bug vtx array overflow temp fix
-        if ((vtx + temp_v1) >= 54) {
-            return;
-        }
         temp_t6 = (vtx + temp_v1)->v.cn[0] * (256 - *arg2);
         temp_t9 = (vtx + temp_v1)->v.cn[1] * (256 - *arg2);
         temp_t7 = (vtx + temp_v1)->v.cn[2] * (256 - *arg2);
@@ -1413,10 +1397,10 @@ void func_80092290(s32 arg0, s32* arg1, s32* arg2) {
         c = ((vtx + temp_v1)->v.cn[2] * *arg2);
         d = ((vtx + temp_v1)->v.cn[3] * *arg2);
 
-        //! @bug vtx array overflow temp fix
-        if ((vtx + idx) >= 54) {
-            return;
-        }
+        (vtx + idx)->v.cn[0] = (temp_t6 + a) / 256;
+        (vtx + idx)->v.cn[1] = (temp_t9 + b) / 256;
+        (vtx + idx)->v.cn[2] = (temp_t7 + c) / 256;
+        (vtx + idx)->v.cn[3] = (temp_t8_2 + d) / 256;
 
         (vtx + idx + 1)->v.cn[0] = (temp_t6 + a) / 256;
         (vtx + idx + 1)->v.cn[1] = (temp_t9 + b) / 256;
@@ -2532,9 +2516,6 @@ Gfx* draw_flash_select_case_fast(Gfx* displayListHead, s32 ulx, s32 uly, s32 lrx
 
 Gfx* func_800959F8(Gfx* displayListHead, Vtx* arg1) {
     s32 index;
-    Vtx* a_D_02007BB8 = (Vtx*) LOAD_ASSET(D_02007BB8);
-    // Vtx *a_D_02007CD8 = (Vtx *) LOAD_ASSET(D_02007CD8);
-    // Vtx *a_D_02007DF8 = (Vtx *) LOAD_ASSET(D_02007DF8);
 
     if ((s32) gTextColor < TEXT_BLUE_GREEN_RED_CYCLE_1) {
         index = gTextColor;
@@ -2542,6 +2523,7 @@ Gfx* func_800959F8(Gfx* displayListHead, Vtx* arg1) {
         index = ((gTextColor * 2) + ((s32) gGlobalTimer % 2)) - 4;
     }
 #ifdef AVOID_UB
+    arg1 = LOAD_ASSET(arg1);
     gSPVertex(displayListHead++, arg1, 2, 0);
     gSPVertex(displayListHead++, &arg1[(index + 1) * 2], 2, 2);
     gSPDisplayList(displayListHead++, common_rectangle_display);
@@ -2636,10 +2618,6 @@ void func_80095AE0(MTX_TYPE* arg0, f32 arg1, f32 arg2, f32 arg3, f32 arg4) {
 Gfx* func_80095BD0(Gfx* displayListHead, u8* arg1, f32 arg2, f32 arg3, u32 arg4, u32 arg5, f32 arg6, f32 arg7) {
     Vtx* var_a1;
     Mtx* sp28;
-
-    Vtx* a_D_02007BB8 = (Vtx*) LOAD_ASSET(D_02007BB8);
-    // Vtx *a_D_02007CD8 = (Vtx *) LOAD_ASSET(D_02007CD8);
-    // Vtx *a_D_02007DF8 = (Vtx *) LOAD_ASSET(D_02007DF8);
 
     // A match is a match, but why are goto's required here?
     if (gMatrixEffectCount >= 0x2F7) {

--- a/yamls/us/data_segment2.yml
+++ b/yamls/us/data_segment2.yml
@@ -62,112 +62,127 @@ D_02007818:
   symbol: D_02007818
   type: Gfx
   offset: 0x7818
-D_02007838:
-  symbol: D_02007838
-  type: Gfx
-  offset: 0x7838
-D_02007858:
-  symbol: D_02007858
-  type: Gfx
-  offset: 0x7858
-D_02007878:
-  symbol: D_02007878
-  type: Gfx
-  offset: 0x7878
-D_02007898:
-  symbol: D_02007898
-  type: Gfx
-  offset: 0x7898
-D_020078B8:
-  symbol: D_020078B8
-  type: Gfx
-  offset: 0x78B8
-D_020078D8:
-  symbol: D_020078D8
-  type: Gfx
-  offset: 0x78D8
-D_020078F8:
-  symbol: D_020078F8
-  type: Gfx
-  offset: 0x78F8
-D_02007918:
-  symbol: D_02007918
-  type: Gfx
-  offset: 0x7918
-D_02007938:
-  symbol: D_02007938
-  type: Gfx
-  offset: 0x7938
-D_02007958:
-  symbol: D_02007958
-  type: Gfx
-  offset: 0x7958
-D_02007978:
-  symbol: D_02007978
-  type: Gfx
-  offset: 0x7978
-D_02007998:
-  symbol: D_02007998
-  type: Gfx
-  offset: 0x7998
-D_020079B8:
-  symbol: D_020079B8
-  type: Gfx
-  offset: 0x79B8
-D_020079D8:
-  symbol: D_020079D8
-  type: Gfx
-  offset: 0x79D8
-D_020079F8:
-  symbol: D_020079F8
-  type: Gfx
-  offset: 0x79F8
-D_02007A18:
-  symbol: D_02007A18
-  type: Gfx
-  offset: 0x7A18
-D_02007A38:
-  symbol: D_02007A38
-  type: Gfx
-  offset: 0x7A38
-D_02007A58:
-  symbol: D_02007A58
-  type: Gfx
-  offset: 0x7A58
-D_02007A78:
-  symbol: D_02007A78
-  type: Gfx
-  offset: 0x7A78
-D_02007A98:
-  symbol: D_02007A98
-  type: Gfx
-  offset: 0x7A98
-D_02007AB8:
-  symbol: D_02007AB8
-  type: Gfx
-  offset: 0x7AB8
-D_02007AD8:
-  symbol: D_02007AD8
-  type: Gfx
-  offset: 0x7AD8
-D_02007AF8:
-  symbol: D_02007AF8
-  type: Gfx
-  offset: 0x7AF8
-D_02007B18:
-  symbol: D_02007B18
-  type: Gfx
-  offset: 0x7B18
+#D_02007838:
+#  symbol: D_02007838
+#  type: Gfx
+#  offset: 0x7838
+#D_02007858:
+#  symbol: D_02007858
+#  type: Gfx
+#  offset: 0x7858
+#D_02007878:
+#  symbol: D_02007878
+#  type: Gfx
+#  offset: 0x7878
+#D_02007898:
+#  symbol: D_02007898
+#  type: Gfx
+#  offset: 0x7898
+#D_020078B8:
+#  symbol: D_020078B8
+#  type: Gfx
+#  offset: 0x78B8
+#D_020078D8:
+#  symbol: D_020078D8
+#  type: Gfx
+#  offset: 0x78D8
+#D_020078F8:
+#  symbol: D_020078F8
+#  type: Gfx
+#  offset: 0x78F8
+#D_02007918:
+#  symbol: D_02007918
+#  type: Gfx
+#  offset: 0x7918
+#D_02007938:
+#  symbol: D_02007938
+#  type: Gfx
+#  offset: 0x7938
+#D_02007958:
+#  symbol: D_02007958
+#  type: Gfx
+#  offset: 0x7958
+#D_02007978:
+#  symbol: D_02007978
+#  type: Gfx
+#  offset: 0x7978
+#D_02007998:
+#  symbol: D_02007998
+#  type: Gfx
+#  offset: 0x7998
+#D_020079B8:
+#  symbol: D_020079B8
+#  type: Gfx
+#  offset: 0x79B8
+#D_020079D8:
+#  symbol: D_020079D8
+#  type: Gfx
+#  offset: 0x79D8
+#D_020079F8:
+#  symbol: D_020079F8
+#  type: Gfx
+#  offset: 0x79F8
+#D_02007A18:
+#  symbol: D_02007A18
+#  type: Gfx
+#  offset: 0x7A18
+#D_02007A38:
+#  symbol: D_02007A38
+#  type: Gfx
+#  offset: 0x7A38
+#D_02007A58:
+#  symbol: D_02007A58
+#  type: Gfx
+#  offset: 0x7A58
+#D_02007A78:
+#  symbol: D_02007A78
+#  type: Gfx
+#  offset: 0x7A78
+#D_02007A98:
+#  symbol: D_02007A98
+#  type: Gfx
+#  offset: 0x7A98
+#D_02007AB8:
+#  symbol: D_02007AB8
+#  type: Gfx
+#  offset: 0x7AB8
+#D_02007AD8:
+#  symbol: D_02007AD8
+#  type: Gfx
+#  offset: 0x7AD8
+#D_02007AF8:
+#  symbol: D_02007AF8
+#  type: Gfx
+#  offset: 0x7AF8
+#D_02007B18:
+#  symbol: D_02007B18
+#  type: Gfx
+#  offset: 0x7B18
 D_02007B38: # unused
   symbol: D_02007B38
   type: vtx
   offset: 0x7B38
-  count: 8
+  count: 4
+D_02007B78: # unused
+  symbol: D_02007B78
+  type: vtx
+  offset: 0x7B78
+  count: 4
 D_02007BB8:
   symbol: D_02007BB8
   type: vtx
   offset: 0x7BB8
-  count: 52
+  count: 18
+D_02007CD8:
+  symbol: D_02007CD8
+  type: vtx
+  offset: 0x7CD8
+  count: 18
+D_02007DF8:
+  symbol: D_02007DF8
+  type: vtx
+  offset: 0x7DF8
+  count: 18
 D_02007F18:
   symbol: D_02007F18
   type: gfx


### PR DESCRIPTION
(Note: These decomp remnants were commited to make updating easier on my end, sorry if they were repeated)

Following the merge of the fixed color font array in decomp, I alterted yml seg2 data extraction to fix the arrays there as well.

Since the code properly calls the vtx in code inside the OTR, I commented out the irrelevant DLs so it won't get extracted.