### PR TITLE
Implement jumbotron framebuffer effect

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -141,6 +141,7 @@ struct SPTask* gGfxSPTask;
 s32 D_801502A0;
 s32 D_801502A4;
 u16* gPhysicalFramebuffers[3];
+u16 gPortFramebuffers[3][SCREEN_WIDTH * SCREEN_HEIGHT];
 uintptr_t gPhysicalZBuffer;
 UNUSED u32 D_801502B8;
 UNUSED u32 D_801502BC;
@@ -910,6 +911,10 @@ void race_logic_loop(void) {
 #if DVDL
     display_dvdl();
 #endif
+    // Copies after all the main rendering is complete. This is accurate to hardware.
+    // This means things like jumbotron will have the pause menu rendered in it.
+    // To avoid that, this line can be moved above func_800591B4.
+    FB_WriteFramebufferSliceToCPU(&gDisplayListHead, gPortFramebuffers[sRenderingFramebuffer], true);
     gDPFullSync(gDisplayListHead++);
     gSPEndDisplayList(gDisplayListHead++);
 }

--- a/src/main.h
+++ b/src/main.h
@@ -182,6 +182,7 @@ extern struct SPTask* gGfxSPTask;
 extern s32 D_801502A0;
 extern s32 D_801502A4;
 extern u16* gPhysicalFramebuffers[];
+extern u16 gPortFramebuffers[3][SCREEN_WIDTH * SCREEN_HEIGHT];
 extern uintptr_t gPhysicalZBuffer;
 extern Mat4 D_801502C0;
 

--- a/src/racing/framebuffer_effects.h
+++ b/src/racing/framebuffer_effects.h
@@ -3,15 +3,13 @@
 
 #include <libultraship.h>
 
-extern s32 gPauseFrameBuffer;
-extern s32 gBlurFrameBuffer;
 extern s32 gReusableFrameBuffer;
 extern s32 gN64ResFrameBuffer;
 
 void FB_CreateFramebuffers(void);
-void FB_CopyToFramebuffer(Gfx* gfx, s32 fb_src, s32 fb_dest, u8 oncePerFrame, u8* hasCopied);
-void FB_WriteFramebufferSliceToCPU(Gfx* gfx, void* buffer, u8 byteSwap);
-void FB_DrawFromFramebuffer(Gfx* gfx, s32 fb, u8 alpha);
-void FB_DrawFromFramebufferScaled(Gfx* gfx, s32 fb, u8 alpha, float scaleX, float scaleY);
+void FB_CopyToFramebuffer(Gfx** gfxP, s32 fb_src, s32 fb_dest, u8 oncePerFrame, u8* hasCopied);
+void FB_WriteFramebufferSliceToCPU(Gfx** gfxP, void* buffer, u8 byteSwap);
+void FB_DrawFromFramebuffer(Gfx** gfxP, s32 fb, u8 alpha);
+void FB_DrawFromFramebufferScaled(Gfx** gfxP, s32 fb, u8 alpha, float scaleX, float scaleY);
 
 #endif // FRAMEBUFFER_EFFECTS_H

--- a/src/racing/render_courses.c
+++ b/src/racing/render_courses.c
@@ -874,6 +874,16 @@ void render_luigi_raceway(struct UnkStruct_800DC5EC* arg0) {
     gSPSetGeometryMode(gDisplayListHead++, G_SHADING_SMOOTH);
     gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);
 
+    // Invalidate Jumbotron textures so they update each frame
+    // This could be more efficient if we exposed the non-opcode based invalidation to be called
+    // inside copy_framebuffers_port
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0xF800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0x10800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0x11800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0x12800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0x13800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0x14800);
+
     if (func_80290C20(arg0->camera) == 1) {
         gDPSetCombineMode(gDisplayListHead++, G_CC_SHADE, G_CC_SHADE);
         gDPSetRenderMode(gDisplayListHead++, G_RM_AA_ZB_OPA_SURF, G_RM_AA_ZB_OPA_SURF2);
@@ -911,11 +921,6 @@ void render_luigi_raceway(struct UnkStruct_800DC5EC* arg0) {
             currentScreenSection = 0;
         }
 
-        u16* fb = (u16*) gSegmentTable[5] + 0xF800;
-
-        // FB_WriteFramebufferSliceToCPU(gDisplayListHead, fb, true);
-        // FB_DrawFromFramebuffer(gDisplayListHead, 0, fb, true);
-        // FB_CopyToFramebuffer(gDisplayListHead, 0, fb, false, NULL);
         /**
          * The jumbo television screen is split into six sections each section is copied one at a time.
          * This is done to fit within the n64's texture size requirements; 64x32
@@ -964,6 +969,10 @@ void render_luigi_raceway(struct UnkStruct_800DC5EC* arg0) {
 #endif
                 break;
         }
+
+        copy_jumbotron_fb_port(D_800DC5DC, D_800DC5E0, currentScreenSection,
+                               (u16*) PHYSICAL_TO_VIRTUAL(gPortFramebuffers[prevFrame]),
+                               (u16*) PHYSICAL_TO_VIRTUAL(gSegmentTable[5] + 0xF800));
     }
 }
 
@@ -1127,6 +1136,16 @@ void render_wario_stadium(struct UnkStruct_800DC5EC* arg0) {
     gSPSetGeometryMode(gDisplayListHead++, G_SHADING_SMOOTH);
     gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);
 
+    // Invalidate Jumbotron textures so they update each frame
+    // This could be more efficient if we exposed the non-opcode based invalidation to be called
+    // inside copy_framebuffers_port
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0x8800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0x9800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0xA800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0xB800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0xC800);
+    gSPInvalidateTexCache(gDisplayListHead++, gSegmentTable[5] + 0xD800);
+
     if (func_80290C20(arg0->camera) == 1) {
 
         gDPSetCombineMode(gDisplayListHead++, G_CC_SHADE, G_CC_SHADE);
@@ -1205,6 +1224,10 @@ void render_wario_stadium(struct UnkStruct_800DC5EC* arg0) {
 #endif
                 break;
         }
+
+        copy_jumbotron_fb_port(D_800DC5DC, D_800DC5E0, currentScreenSection,
+                               (u16*) PHYSICAL_TO_VIRTUAL(gPortFramebuffers[prevFrame]),
+                               (u16*) PHYSICAL_TO_VIRTUAL(gSegmentTable[5] + 0x8800));
     }
 }
 

--- a/src/racing/skybox_and_splitscreen.c
+++ b/src/racing/skybox_and_splitscreen.c
@@ -1423,6 +1423,49 @@ void copy_framebuffer(s32 arg0, s32 arg1, s32 width, s32 height, u16* source, u1
     }
 }
 
+// Handles copying framebuffer to course texture data region for the Jumbotron in the port
+// This only supports framebuffers and copy regions being within 320x240
+// Any attempt to support larger sizes would require reworking course data
+void copy_jumbotron_fb_port(s32 ulx, s32 uly, s16 portionToDraw, u16* source, u16* target) {
+    // Add CVar if we want to expose a user toggle for only updating 1/6 of the jumbotron per frame
+    u8 updateWholeJumbo = true;
+
+    ulx = 0;
+    uly = 0;
+
+    if (portionToDraw == -1 || updateWholeJumbo) {
+        copy_framebuffer(ulx, uly, 64, 32, source, target);
+        copy_framebuffer(ulx + 64, uly, 64, 32, source, target + (64 * 32 * 1));
+        copy_framebuffer(ulx, uly + 32, 64, 32, source, target + (64 * 32 * 2));
+        copy_framebuffer(ulx + 64, uly + 32, 64, 32, source, target + (64 * 32 * 3));
+        copy_framebuffer(ulx, uly + 64, 64, 32, source, target + (64 * 32 * 4));
+        copy_framebuffer(ulx + 64, uly + 64, 64, 32, source, target + (64 * 32 * 5));
+    } else {
+        switch (portionToDraw) {
+            case 0:
+                copy_framebuffer(ulx, uly, 64, 32, source, target);
+                break;
+            case 1:
+                copy_framebuffer(ulx + 64, uly, 64, 32, source, target + (64 * 32 * 1));
+                break;
+            case 2:
+                copy_framebuffer(ulx, uly + 32, 64, 32, source, target + (64 * 32 * 2));
+                break;
+            case 3:
+                copy_framebuffer(ulx + 64, uly + 32, 64, 32, source, target + (64 * 32 * 3));
+                break;
+            case 4:
+                copy_framebuffer(ulx, uly + 64, 64, 32, source, target + (64 * 32 * 4));
+                break;
+            case 5:
+                copy_framebuffer(ulx + 64, uly + 64, 64, 32, source, target + (64 * 32 * 5));
+                break;
+            default:
+                break;
+        }
+    }
+}
+
 void func_802A7728(void) {
     s16 temp_v0;
 
@@ -1438,6 +1481,7 @@ void func_802A7728(void) {
     } else if (temp_v0 > 2) {
         temp_v0 = 0;
     }
+#if TARGET_N64
     copy_framebuffer(D_800DC5DC, D_800DC5E0, 64, 32, (u16*) PHYSICAL_TO_VIRTUAL(gPhysicalFramebuffers[temp_v0]),
                      (u16*) PHYSICAL_TO_VIRTUAL(gSegmentTable[5] + 0x8800));
     copy_framebuffer(D_800DC5DC + 64, D_800DC5E0, 64, 32, (u16*) PHYSICAL_TO_VIRTUAL(gPhysicalFramebuffers[temp_v0]),
@@ -1452,6 +1496,10 @@ void func_802A7728(void) {
     copy_framebuffer(D_800DC5DC + 64, D_800DC5E0 + 64, 64, 32,
                      (u16*) PHYSICAL_TO_VIRTUAL(gPhysicalFramebuffers[temp_v0]),
                      (u16*) PHYSICAL_TO_VIRTUAL(gSegmentTable[5] + 0xD800));
+#else
+    copy_jumbotron_fb_port(D_800DC5DC, D_800DC5E0, -1, PHYSICAL_TO_VIRTUAL(gPortFramebuffers[temp_v0]),
+                           (u16*) PHYSICAL_TO_VIRTUAL(gSegmentTable[5] + 0x8800));
+#endif
 }
 
 void func_802A7940(void) {
@@ -1469,6 +1517,7 @@ void func_802A7940(void) {
     } else if (temp_v0 > 2) {
         temp_v0 = 0;
     }
+#if TARGET_N64
     copy_framebuffer(D_800DC5DC, D_800DC5E0, 0x40, 0x20, (u16*) PHYSICAL_TO_VIRTUAL(gPhysicalFramebuffers[temp_v0]),
                      (u16*) PHYSICAL_TO_VIRTUAL(gSegmentTable[5] + 0xF800));
     copy_framebuffer(D_800DC5DC + 0x40, D_800DC5E0, 0x40, 0x20,
@@ -1486,4 +1535,8 @@ void func_802A7940(void) {
     copy_framebuffer(D_800DC5DC + 0x40, D_800DC5E0 + 0x40, 0x40, 0x20,
                      (u16*) PHYSICAL_TO_VIRTUAL(gPhysicalFramebuffers[temp_v0]),
                      (u16*) PHYSICAL_TO_VIRTUAL(gSegmentTable[5] + 0x14800));
+#else
+    copy_jumbotron_fb_port(D_800DC5DC, D_800DC5E0, -1, (u16*) PHYSICAL_TO_VIRTUAL(gPortFramebuffers[temp_v0]),
+                           (u16*) PHYSICAL_TO_VIRTUAL(gSegmentTable[5] + 0xF800));
+#endif
 }

--- a/src/racing/skybox_and_splitscreen.h
+++ b/src/racing/skybox_and_splitscreen.h
@@ -53,6 +53,7 @@ void render_player_three_3p_4p_screen(void);
 void render_player_four_3p_4p_screen(void);
 void func_802A74BC(void);
 void copy_framebuffer(s32, s32, s32, s32, u16*, u16*);
+void copy_jumbotron_fb_port(s32 ulx, s32 uly, s16 portionToDraw, u16* source, u16* target);
 void func_802A7728(void);
 void func_802A7940(void);
 


### PR DESCRIPTION
This implements the jumbotron in a way that supports how ports/LUS deal with framebuffer effects.
The jumbotron is limited to framebuffer copies that are 320x240 scales of the main framebuffer.

3 sets of framebuffers are statically declared for the ports use so that we can copy the 320x240 RGBA16 frame scaled frame data from GPU to CPU, and then later this will get copied into gSegment[5] to be read by the course display lists.

I've defaulted the behavior so that the jumbotron updates its whole display in one frame, instead of 1/6th at a time. A CVar can be added for purist later if you want.

Additionally I placed the framebuffer copy after all rendering, which means the games pause menu will be reflected in the jumbotron. I believe this is accurate to hardware from what I read online, but someone will have to confirm.
Otherwise we can move the copy to be earlier to avoid that behavior.

Demo showing the 1/6th update in action:

https://github.com/user-attachments/assets/a3e34dfb-548a-4cce-8c09-601ba161f593

