### PR TITLE
Windows compile min-max fix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
             "NDEBUG"
         ">"
         "INCLUDE_GAME_PRINTF;"
+        "NOMINMAX"
         "UNICODE;"
         "_UNICODE;"
         "_CRT_SECURE_NO_WARNINGS;"


### PR DESCRIPTION
A fix suggested by Malkierian that should not break Linux or MacOS.