### PR TITLE
Add vcpkg.json, change MacOS CI to use that

### DIFF
--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -12,10 +12,14 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: brew install sdl2 libpng glew ninja cmake libzip nlohmann-json tinyxml2 spdlog vorbis-tools
+        run: brew install ninja cmake
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgDirectory: '${{ github.workspace }}/vcpkg'
       - name: Build
         run: |
-          cmake -H. -Bbuild-cmake -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release
+          cmake -H. -Bbuild-cmake -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
           cmake --build build-cmake -j
       - name: Create Package
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,10 +82,14 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: brew install sdl2 sdl2_net libpng glew ninja cmake libzip nlohmann-json tinyxml2 spdlog vorbis-tools
+        run: brew install ninja cmake
+      - name: Install vcpkg
+        uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgDirectory: '${{ github.workspace }}/vcpkg'
       - name: Build
         run: |
-          cmake -H. -Bbuild-cmake -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release
+          cmake -H. -Bbuild-cmake -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
           cmake --build build-cmake --config Release -j3
       - name: Download spaghetti.o2r
         uses: actions/download-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ cmake-build-*/
 .vs
 build*/
 .DS_Store
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,7 +393,6 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     find_package(Vorbis CONFIG REQUIRED)
     link_libraries(Vorbis::vorbisfile)
 	set(ADDITIONAL_LIBRARY_DEPENDENCIES
-        "$<$<BOOL:${USE_NETWORKING}>:SDL2_net::SDL2_net-static>"
         "Ogg::ogg"
         "Vorbis::vorbis"
         "Vorbis::vorbisenc"
@@ -416,7 +415,6 @@ else()
     find_package(Ogg REQUIRED)
     find_package(Vorbis REQUIRED)
  	set(ADDITIONAL_LIBRARY_DEPENDENCIES
-        "$<$<BOOL:${USE_NETWORKING}>:SDL2_net::SDL2_net>"
         "Ogg::ogg"
         "Vorbis::vorbis"
         "Vorbis::vorbisenc"
@@ -435,7 +433,7 @@ if(USE_NETWORKING)
         target_link_libraries(${PROJECT_NAME} PRIVATE SDL2_net)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         find_package(SDL2_net REQUIRED)
-        target_link_libraries(${PROJECT_NAME} PRIVATE SDL2_net::SDL2_net) 
+        target_link_libraries(${PROJECT_NAME} PRIVATE $<IF:$<TARGET_EXISTS:SDL2_net::SDL2_net>,SDL2_net::SDL2_net,SDL2_net::SDL2_net-static>) 
     else()
         find_package(SDL2_net REQUIRED)
         target_link_libraries(${PROJECT_NAME} PRIVATE SDL2_net::SDL2_net-static)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -18,6 +18,6 @@
     "libogg",
     "libvorbis"
   ],
-  "builtin-baseline": "efb1e7436979a30c4d3e5ab2375fd8e2e461d541",
+  "builtin-baseline": "2e58bb35ff7a3a037920d959ce20cb4d8c22319a",
   "overrides": []
-} 
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "spaghettikart",
+  "version": "1.0.0",
+  "description": "A Mario Kart 64 port",
+  "homepage": "https://github.com/HarbourMasters/SpaghettiKart",
+  "dependencies": [
+    "zlib",
+    "bzip2",
+    "libzip",
+    "libpng",
+    "sdl2",
+    "sdl2-net",
+    "glew",
+    "glfw3",
+    "nlohmann-json",
+    "tinyxml2",
+    "spdlog",
+    "libogg",
+    "libvorbis"
+  ],
+  "builtin-baseline": "efb1e7436979a30c4d3e5ab2375fd8e2e461d541",
+  "overrides": []
+} 


### PR DESCRIPTION
The MacOS CI was using brew for all the dependencies before, which meant that it was linking to all the dependencies dynamically and as a result the uploaded binary did not work. This PR changes the dependency manager for the MacOS build to vcpkg, which enables us to compile all the dependencies statically.