### PR TITLE
Fix Clear Crossing Crash

### DIFF
--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -296,7 +296,9 @@ void CM_DrawBattleBombKarts(s32 cameraId) {
 }
 
 void CM_ClearVehicles(void) {
-    gWorldInstance.Crossings.clear();
+    if (!gWorldInstance.Crossings.empty()) {
+        gWorldInstance.Crossings.clear();
+    }
 }
 
 void CM_CrossingTrigger() {


### PR DESCRIPTION
This appears to be an obscure bug at the end of a kalimari race.

This needs testing to confirm that the fix actually works.