### PR TITLE
Add L&R and Gamepad to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Congratulations, you are now sailing with SpaghettiKart! Have fun!
 
 # Configuration
 
-### Default keyboard configuration
-| N64 | A | B | Z | Start | Analog stick | C buttons | D-Pad |
-| - | - | - | - | - | - | - | - |
-| Keyboard | Shift | Ctrl | Z | Enter | Arrow keys | TGFH (↑ ↓ ← →) | Num 8 2 4 6 |
+### Default controls configuration
+| N64 | A | B | L | R | Z | Start | Analog stick | C buttons | D-Pad |
+| - | - | - | - | - | - | - | - | - | - |
+| Keyboard | Shift | Ctrl | Q | Space | Z | Enter | Arrow keys | TGFH (↑ ↓ ← →) | Num 8 2 4 6 |
+| SDL Gamepad | A | X | LB | RB | LT | Start | L-Stick | R-Stick Up, B, Y, R-Stick Right (↑ ↓ ← →) | D-Pad |
 
 ### Other shortcuts
 | Keys | Action |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Congratulations, you are now sailing with SpaghettiKart! Have fun!
 # Configuration
 
 ### Default controls configuration
-| N64 | A | B | L | R | Z | Start | Analog stick | C buttons | D-Pad |
+| N64 | A | B | L | R | Z | Start | Analogue stick | C buttons | D-Pad |
 | - | - | - | - | - | - | - | - | - | - |
 | Keyboard | Shift | Ctrl | Q | Space | Z | Enter | Arrow keys | TGFH (↑ ↓ ← →) | Num 8 2 4 6 |
 | SDL Gamepad | A | X | LB | RB | LT | Start | L-Stick | R-Stick Up, B, Y, R-Stick Right (↑ ↓ ← →) | D-Pad |


### PR DESCRIPTION
Adds the N64 `L` and `R` buttons and the SDL Gamepad controls (which I took from the settings) to the README.