### PR TITLE
Fix MacOS build in GitHub workflow

### DIFF
--- a/.github/workflows/macos-compile.yml
+++ b/.github/workflows/macos-compile.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create Package
         run: |
           mkdir spaghetti-release
-          mv build-cmake/spaghetti spaghetti-release/
+          mv build-cmake/Spaghettify spaghetti-release/
       - name: Publish packaged artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Making it the same as in the Linux workflow