### PR TITLE
Add kartPropulsionStrength and waterInteractionFlags

### DIFF
--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -294,7 +294,7 @@ typedef struct {
     /* 0x0080 */ f32 boostPower;
     /* 0x0084 */ f32 unk_084;
     /* 0x0088 */ f32 unk_088;
-    /* 0x008C */ f32 unk_08C;
+    /* 0x008C */ f32 kartPropulsionStrength;
     /* 0x0090 */ f32 unk_090;
     /* 0x0094 */ f32 speed;
     /* 0x0098 */ f32 unk_098;
@@ -320,7 +320,7 @@ typedef struct {
     /* 0x00CC */ Vec4s unk_0CC;
     /* 0x00D4 */ Vec4s unk_0D4;
     /* 0x00DC */ s16 boostTimer;
-    /* 0x00DE */ u16 unk_0DE;
+    /* 0x00DE */ u16 waterInteractionFlags;
     /* 0x00E0 */ s16 unk_0E0;
     /* 0x00E2 */ s16 unk_0E2;
     /* 0x00E4 */ f32 unk_0E4;

--- a/include/defines.h
+++ b/include/defines.h
@@ -409,6 +409,18 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define COLOR_LAVA GPACK_RGB888(0x34, 0x00, 0x00)
 #define COLOR_BLACK GPACK_RGB888(0, 0, 0)
 
+
+/**
+ * @brief player water interaction flags (player->unk_0DE)
+ *
+ */
+
+#define WATER_NO_INTERACTION 0x0000             // No water interaction
+#define WATER_IS_FULLY_SUBMERGED 0x0001         // Kart is completely underwater
+#define WATER_IS_PARTIALLY_SUBMERGED 0x0002     // Kart is partially in the water
+#define WATER_IN_DEEP_LIQUID_STATE 0x0004       // Persistent flag for being in a deep liquid state?
+#define WATER_JUST_ENTERED_DEEP_LIQUID 0x0008   // Momentary flag for the instant of entering deep liquid
+
 /**
  *
  * Collision mesh flags

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -593,7 +593,7 @@ void func_800C2474(void) {
         gPlayers[var_v0].unk_20C = 0.0f;
         gPlayers[var_v0].unk_0C0 = 0;
         gPlayers[var_v0].unk_098 = 0.0f;
-        gPlayers[var_v0].unk_0DE = 0;
+        gPlayers[var_v0].waterInteractionFlags = WATER_NO_INTERACTION;
         D_8018FC10[var_v0][0] = 0x00FF;
         D_8018FC10[var_v0][1] = 0;
         D_800EA10C[var_v0] = 0;
@@ -2689,7 +2689,7 @@ void func_800C76C0(u8 playerId) {
 }
 
 void func_800C847C(u8 playerId) {
-    if ((gPlayers[playerId].unk_0DE & 1) == 1) {
+    if ((gPlayers[playerId].waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) == WATER_IS_FULLY_SUBMERGED) {
         if (D_800E9F74[playerId] == 0) {
             if ((s32) D_800EA1C0 < 2) {
                 func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0xF9, 0x26));

--- a/src/camera.c
+++ b/src/camera.c
@@ -548,8 +548,8 @@ void func_8001CCEC(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
         *arg4 = camera->pos[1] + (((y - camera->pos[1]) * 0.15));
     }
 
-    if ((player->unk_0DE & 1) != 0) {
-        *arg4 = D_801652A0[index];
+    if ((player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) != 0) {
+        *arg4 = gPlayerWaterLevel[index];
     }
 }
 
@@ -571,7 +571,7 @@ void func_8001D53C(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
     } else {
         move_f32_towards(&camera->unk_A0, 0.0f, 0.06f);
     }
-    thing = D_801652A0[arg7];
+    thing = gPlayerWaterLevel[arg7];
     sp68[0] = camera->unk_30[0];
     sp68[1] = camera->unk_30[1];
     sp68[2] = camera->unk_30[2];
@@ -768,8 +768,8 @@ void func_8001D944(Player* player, Camera* camera, Vec3f arg2, f32* arg3, f32* a
         *arg4 = camera->pos[1] + (((y - camera->pos[1]) * 0.15));
     }
 
-    if ((player->unk_0DE & 1) != 0) {
-        *arg4 = D_801652A0[index];
+    if ((player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) != 0) {
+        *arg4 = gPlayerWaterLevel[index];
     }
 }
 

--- a/src/code_8003DC40.c
+++ b/src/code_8003DC40.c
@@ -74,7 +74,7 @@ void func_8003E048(Player* player, Vec3f arg1, Vec3f arg2, Vec3f arg3, f32* arg4
         if ((player->effects & BOOST_EFFECT) != 0) {
             remove_boost_effect(player);
             player->currentSpeed /= 2;
-            player->unk_08C /= 2;
+            player->kartPropulsionStrength /= 2;
         }
     } else if ((((player->speed / 18.0f) * 216.0f) > 20.0f) || ((player->effects & 0x10000) == 0x10000)) {
         arg3[0] = ((player->unk_206 / 182) * 0x32);
@@ -102,7 +102,7 @@ void func_8003E37C(Player* player, Vec3f arg1, Vec3f arg2, Vec3f arg3, f32* arg4
         if ((player->effects & BOOST_EFFECT) != 0) {
             remove_boost_effect(player);
             player->currentSpeed /= 2;
-            player->unk_08C /= 2;
+            player->kartPropulsionStrength /= 2;
         }
     } else if ((((player->speed / 18.0f) * 216.0f) > 20.0f) || ((player->effects & 0x10000) == 0x10000)) {
         arg3[0] = ((player->unk_206 / 182) * 0x32);

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -3119,7 +3119,7 @@ void func_8005EA94(Player* player, s16 arg1, s32 arg2, s8 arg3, UNUSED s8 arg4) 
     surfaceType = 0x000000FF;
     temp_v0 = random_int(test);
     if ((temp_v0 == 0) || (temp_v0 == 8)) {
-        if ((D_801652A0[arg3] - player->tyres[BACK_LEFT].baseHeight) >= 3.5) {
+        if ((gPlayerWaterLevel[arg3] - player->tyres[BACK_LEFT].baseHeight) >= 3.5) {
             x = player->tyres[BACK_LEFT].pos[0];
             y = player->tyres[BACK_LEFT].baseHeight + 2.0f;
             z = player->tyres[BACK_LEFT].pos[2];
@@ -3128,7 +3128,7 @@ void func_8005EA94(Player* player, s16 arg1, s32 arg2, s8 arg3, UNUSED s8 arg4) 
         }
     }
     if ((temp_v0 == 2) || (temp_v0 == 6)) {
-        if ((D_801652A0[arg3] - player->tyres[BACK_RIGHT].baseHeight) >= 3.5) {
+        if ((gPlayerWaterLevel[arg3] - player->tyres[BACK_RIGHT].baseHeight) >= 3.5) {
             x = player->tyres[BACK_RIGHT].pos[0];
             y = player->tyres[BACK_RIGHT].baseHeight + 2.0f;
             z = player->tyres[BACK_RIGHT].pos[2];
@@ -3603,14 +3603,14 @@ void func_800608E0(Player* player, s16 arg1, UNUSED s32 arg2, s8 arg3, UNUSED s8
     f32 sp4C;
     f32 sp48;
 
-    var_f0 = 8.0f - (D_801652A0[arg3] - player->pos[1]);
+    var_f0 = 8.0f - (gPlayerWaterLevel[arg3] - player->pos[1]);
     if ((f64) var_f0 <= 0.0) {
         var_f0 = 0.0f;
     }
-    sp4C = (D_801652A0[arg3] - player->pos[1]) - 3.0f;
-    if ((player->unk_0DE & 1) && (!IsKoopaTroopaBeach())) {
+    sp4C = (gPlayerWaterLevel[arg3] - player->pos[1]) - 3.0f;
+    if ((player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) && (!IsKoopaTroopaBeach())) {
         var_f0 = 2.5f;
-        sp4C = (f32) ((f64) (D_801652A0[arg3] - player->pos[1]) + 0.1);
+        sp4C = (f32) ((f64) (gPlayerWaterLevel[arg3] - player->pos[1]) + 0.1);
     }
     set_particle_position_and_rotation(player, &player->particlePool0[arg1], 0.0f, 0.0f, 0.0f, (s8) 0, (s8) 0);
     init_particle_player(&player->particlePool0[arg1], 3, var_f0);
@@ -3694,8 +3694,8 @@ void func_80060F50(Player* player, s16 arg1, UNUSED s32 arg2, s8 arg3, UNUSED s8
         player->pos[2] + (coss(player->particlePool0[arg1].unk_020) * -5.8);
     player->particlePool0[arg1].pos[0] =
         player->pos[0] + (sins(player->particlePool0[arg1].unk_020) * -5.8);
-    player->particlePool0[arg1].pos[1] = D_801652A0[arg3];
-    player->unk_0DE &= ~0x0008;
+    player->particlePool0[arg1].pos[1] = gPlayerWaterLevel[arg3];
+    player->waterInteractionFlags &= ~WATER_JUST_ENTERED_DEEP_LIQUID;
 }
 
 void func_80061094(Player* player, s16 arg1, UNUSED s32 arg2, UNUSED s8 arg3, UNUSED s8 arg4) {
@@ -4275,13 +4275,13 @@ void func_80062F98(Player* player, s16 arg1, s8 arg2, UNUSED s8 arg3) {
     if ((player->unk_0CA & 1) == 1) {
         player->particlePool1[arg1].pos[1] += (temp_f0 + 0.3);
         if ((player->particlePool1[arg1].unk_01E == 0x10) ||
-            ((D_801652A0[arg2] - player->particlePool1[arg1].pos[1]) < 3.0f)) {
+            ((gPlayerWaterLevel[arg2] - player->particlePool1[arg1].pos[1]) < 3.0f)) {
             player->particlePool1[arg1].isAlive = 0;
             player->particlePool1[arg1].unk_01E = 0;
             player->particlePool1[arg1].type = 0;
         }
     } else if ((player->particlePool1[arg1].unk_01E == 0xA) ||
-               ((D_801652A0[arg2] - player->particlePool1[arg1].pos[1]) < 3.0f)) {
+               ((gPlayerWaterLevel[arg2] - player->particlePool1[arg1].pos[1]) < 3.0f)) {
         player->particlePool1[arg1].isAlive = 0;
         player->particlePool1[arg1].unk_01E = 0;
         player->particlePool1[arg1].type = 0;
@@ -4292,7 +4292,7 @@ void set_oob_splash_particle_position(Player* player, s16 arg1, s8 arg2, UNUSED 
     ++player->particlePool0[arg1].unk_01E;
     player->particlePool0[arg1].pos[2] = player->pos[2] + coss(player->particlePool0[arg1].unk_020) * -5.8;
     player->particlePool0[arg1].pos[0] = player->pos[0] + sins(player->particlePool0[arg1].unk_020) * -5.8;
-    player->particlePool0[arg1].pos[1] = D_801652A0[arg2];
+    player->particlePool0[arg1].pos[1] = gPlayerWaterLevel[arg2];
     if (player->particlePool0[arg1].unk_01E == 15) {
         player->particlePool0[arg1].isAlive = 0;
         player->particlePool0[arg1].unk_01E = 0;
@@ -4611,9 +4611,9 @@ void func_80064184(Player* player, s16 arg1, s8 arg2, UNUSED s8 arg3) {
     f32 sp40;
     f32 sp3C;
 
-    sp40 = D_801652A0[arg2] - player->pos[1] - 3.0f;
-    if (((player->unk_0DE & 1) != 0) && (!IsKoopaTroopaBeach())) {
-        sp40 = D_801652A0[arg2] - player->pos[1] + 0.1;
+    sp40 = gPlayerWaterLevel[arg2] - player->pos[1] - 3.0f;
+    if (((player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) != 0) && (!IsKoopaTroopaBeach())) {
+        sp40 = gPlayerWaterLevel[arg2] - player->pos[1] + 0.1;
     }
 
     func_80062B18(&sp44, &sp40, &sp3C, 0.0f, sp40,
@@ -4624,7 +4624,7 @@ void func_80064184(Player* player, s16 arg1, s8 arg2, UNUSED s8 arg3) {
     player->particlePool0[arg1].pos[1] = player->pos[1] + sp40;
     ++player->particlePool0[arg1].unk_01E;
     if ((player->particlePool0[arg1].unk_01E == 12) ||
-        (D_801652A0[arg2] <= (player->pos[1] - player->boundingBoxSize))) {
+        (gPlayerWaterLevel[arg2] <= (player->pos[1] - player->boundingBoxSize))) {
         player->particlePool0[arg1].isAlive = 0;
         player->particlePool0[arg1].unk_01E = 0;
         player->particlePool0[arg1].type = 0;
@@ -6339,14 +6339,14 @@ void func_8006C6AC(Player* player, s16 particleIndex, s8 arg2, s8 arg3) {
                 break;
         }
     } else {
-        if (player->unk_0DE & 1) {
+        if (player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) {
             func_80060BCC(player, particleIndex, sp28, arg2_copy, arg3);
         } else if (!(player->effects & 8) && !(player->effects & 2)) {
             if (((player->effects & DRIFTING_EFFECT) == DRIFTING_EFFECT) &&
                 ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) {
                 check_drift_particles_setup_valid(player, particleIndex, sp28, arg2_copy, arg3);
-            } else if (((f64) (D_801652A0[arg2_copy] - player->tyres[BACK_RIGHT].baseHeight) >= 3.5) ||
-                       ((f64) (D_801652A0[arg2_copy] - player->tyres[BACK_LEFT].baseHeight) >= 3.5)) {
+            } else if (((f64) (gPlayerWaterLevel[arg2_copy] - player->tyres[BACK_RIGHT].baseHeight) >= 3.5) ||
+                       ((f64) (gPlayerWaterLevel[arg2_copy] - player->tyres[BACK_LEFT].baseHeight) >= 3.5)) {
                 func_8005EA94(player, particleIndex, sp28, arg2_copy, arg3);
             } else if (((player->effects & 0x80) == 0x80) || ((player->effects & 0x40) == 0x40)) {
                 func_8005F90C(player, particleIndex, sp28, arg2_copy, arg3);
@@ -6495,10 +6495,10 @@ void func_8006CEC0(Player* player, s16 arg1, s8 arg2, s8 arg3) {
             func_80061094(player, arg1, sp20, arg2, arg3);
             return;
         } else if ((player->type & 0x4000) == 0x4000) {
-            if ((player->unk_0DE & 8) == 8) {
+            if ((player->waterInteractionFlags & WATER_JUST_ENTERED_DEEP_LIQUID) == WATER_JUST_ENTERED_DEEP_LIQUID) {
                 func_80060F50(player, arg1, sp20, arg2, arg3);
                 return;
-            } else if ((player->unk_0DE & 2) || (player->unk_0DE & 1)) {
+            } else if ((player->waterInteractionFlags & WATER_IS_PARTIALLY_SUBMERGED) || (player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED)) {
                 func_80060B14(player, arg1, sp20, arg2, arg3);
                 return;
             }

--- a/src/code_80057C60.h
+++ b/src/code_80057C60.h
@@ -266,7 +266,7 @@ extern u8** D_800E47A0[];
 extern s32 D_800E47DC[];
 extern s32 D_800E480C[];
 
-extern f32 D_801652A0[];
+extern f32 gPlayerWaterLevel[];
 
 extern s32 D_80165590;
 extern s32 D_80165594;

--- a/src/code_80086E70.c
+++ b/src/code_80086E70.c
@@ -954,7 +954,7 @@ UNUSED bool func_80088F94(s32 objectIndex, Player* player, f32 arg2) {
     return var_v1;
 }
 
-void func_80088FF0(Player* player) {
+void reset_player_speed_and_velocity(Player* player) {
     player->kartPropulsionStrength = 0.0f;
     player->currentSpeed = 0.0f;
     player->velocity[0] = 0.0f;

--- a/src/code_80086E70.c
+++ b/src/code_80086E70.c
@@ -955,14 +955,14 @@ UNUSED bool func_80088F94(s32 objectIndex, Player* player, f32 arg2) {
 }
 
 void func_80088FF0(Player* player) {
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
     player->currentSpeed = 0.0f;
     player->velocity[0] = 0.0f;
     player->velocity[2] = 0.0f;
 }
 
 UNUSED void func_8008900C(Player* player) {
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
     player->currentSpeed = 0.0f;
 }
 

--- a/src/code_80086E70.h
+++ b/src/code_80086E70.h
@@ -76,7 +76,7 @@ bool has_collided_with_player_1d(s32, Player*, f32);
 bool has_collided_with_player_and_within_height(s32, Player*, f32);
 f32 func_80088F54(s32, Player*);
 UNUSED bool func_80088F94(s32, Player*, f32);
-void func_80088FF0(Player*);
+void reset_player_speed_and_velocity(Player*);
 void func_8008900C(Player*);
 void func_80089020(s32, f32*);
 void func_800892E0(s32);

--- a/src/effects.c
+++ b/src/effects.c
@@ -724,7 +724,7 @@ void apply_hit_effect(Player* player, s8 arg1) {
     player->unk_0A8 = 0;
     player->unk_07C = 0;
     player->unk_0C0 = 0;
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
     player->currentSpeed = 0.0f;
     // clang-format off
     if ((player->collision.surfaceDistance[2] >= 600.0f) || ((player->effects & 0x1000) != 0)) { D_8018D990[arg1] = 3; } // placed block on same line to match
@@ -833,7 +833,7 @@ void apply_hit_rotating_sound_effect(Player* player, s8 arg1) {
     player->soundEffects &= ~HIT_ROTATING_SOUND_EFFECT;
     player->effects |= 0x40020000;
     player->effects &= ~0x10;
-    player->unk_08C *= 0.6;
+    player->kartPropulsionStrength *= 0.6;
     player->unk_0B0 = 0;
     player->size = 1.0f;
     gPlayerStarEffectStartTime[arg1] = gCourseTimer;
@@ -896,7 +896,7 @@ void apply_lightning_effect(Player* player, s8 arg1) {
         player_decelerate(player, 1.0f);
     } else {
         player->unk_0B0 += 1;
-        player->unk_08C = (f32) ((f64) player->unk_08C * 0.6);
+        player->kartPropulsionStrength = (f32) ((f64) player->kartPropulsionStrength * 0.6);
         if ((player->unk_0B0 == 1) && (player->type & PLAYER_HUMAN)) {
             func_800C90F4(arg1, (player->characterId * 0x10) + 0x29008005);
         }
@@ -938,7 +938,7 @@ void func_8008E4A4(Player* player, s8 arg1) {
     player->unk_07C = 0;
     player->unk_0C2 = 0xF;
     player->unk_042 += 0xAAA;
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
     player->currentSpeed = 0.0f;
     player->velocity[0] = 0.0f;
     player->velocity[2] = 0.0f;
@@ -1051,7 +1051,7 @@ void apply_hit_by_item_effect(Player* player, s8 arg1) {
     player->unk_07C = 0;
     player->unk_0C2 = 0xF;
     player->unk_042 += 0xAAA;
-    player->unk_08C /= 2;
+    player->kartPropulsionStrength /= 2;
     player->currentSpeed = 0.0f;
     player->effects &= ~0xC0;
 
@@ -1183,7 +1183,7 @@ void apply_boost_ramp_asphalt_effect(Player* player) {
         if (player->unk_0C2 >= 0x33) {
             temp_f0 = 0.7;
             player->currentSpeed = (player->currentSpeed * temp_f0);
-            player->unk_08C = (player->unk_08C * temp_f0);
+            player->kartPropulsionStrength = (player->kartPropulsionStrength * temp_f0);
         }
     }
 }
@@ -1226,7 +1226,7 @@ void apply_boost_ramp_wood_effect(Player* player) {
         player->effects &= ~BOOST_RAMP_WOOD_EFFECT;
         player->boostPower = 0.0f;
         player->currentSpeed /= 2;
-        player->unk_08C /= 2;
+        player->kartPropulsionStrength /= 2;
     }
 }
 
@@ -1255,7 +1255,7 @@ void func_8008F104(Player* player, s8 arg1) {
 void func_8008F1B8(Player* player, s8 arg1) {
     s16 temp;
 
-    player->unk_08C = (player->unk_210 * 0.05);
+    player->kartPropulsionStrength = (player->unk_210 * 0.05);
     if (player->unk_0B2 < 0) {
         if ((player->unk_044 & 0x80) == 0x80) {
             player->rotation[1] += 182;
@@ -1310,7 +1310,7 @@ void func_8008F3F4(Player* player, UNUSED s8 arg1) {
     player->unk_042 += 0x71C;
     player->unk_07C = 0;
     player->currentSpeed = 0.0f;
-    player->unk_08C /= 2;
+    player->kartPropulsionStrength /= 2;
     if (player->unk_0A8 >= 0x2000) {
         player->unk_0A8 = 0;
         --player->unk_236;
@@ -1339,7 +1339,7 @@ void func_8008F494(Player* player, s8 arg1) {
     player->unk_042 = 0;
 
     if (((player->type & PLAYER_HUMAN) != 0) && ((player->type & PLAYER_INVISIBLE_OR_BOMB) == 0) &&
-        ((player->unk_0CA & 2) == 0) && ((player->unk_0DE & 1) == 0) && ((player->unk_0DE & 2) == 0)) {
+        ((player->unk_0CA & 2) == 0) && ((player->waterInteractionFlags & 1) == 0) && ((player->waterInteractionFlags & 2) == 0)) {
         func_800C90F4(arg1, (player->characterId * 0x10) + 0x29008004);
     }
 }
@@ -1577,7 +1577,7 @@ void func_8008FE84(Player* player, UNUSED s8 arg1) {
     if ((player->effects & 8) != 8) {
         player->effects &= ~0x10000000;
         player->currentSpeed /= 2;
-        player->unk_08C /= 2;
+        player->kartPropulsionStrength /= 2;
     }
 }
 
@@ -1762,7 +1762,7 @@ void func_80090778(Player* player) {
     player->unk_0CA |= 8;
     player->effects &= ~0x10;
     player->unk_222 = 0;
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
 
     clean_effect(player, playerIndex);
     func_8008F86C(player, playerIndex);
@@ -1789,7 +1789,7 @@ void func_80090868(Player* player) {
     player->unk_078 = 0;
     player->unk_07C = 0;
     player->unk_0C0 = 0;
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
     playerIndex = get_player_index_for_player(player);
 
     if ((player->unk_0CA & 2) != 2) {
@@ -1800,7 +1800,7 @@ void func_80090868(Player* player) {
         player->unk_222 = 0;
         player->unk_0CA |= 2;
         player->unk_0C8 = 0;
-        if ((player->unk_0DE & 1) == 1) {
+        if ((player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) == WATER_IS_FULLY_SUBMERGED) {
             if ((IsBowsersCastle()) || (IsBigDonut())) {
                 player->unk_0CA |= 0x1000;
             } else {
@@ -1828,7 +1828,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
     player->unk_078 = 0;
     player->unk_07C = 0;
     player->unk_0C0 = 0;
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
     clean_effect(player, playerId);
     switch (player->unk_222) {
         case 0:
@@ -1839,9 +1839,9 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                         player->unk_0C8 = 0x003C;
                     }
                 } else {
-                    move_f32_towards(&player->pos[1], D_801652A0[playerId] + 100.0f, 0.012f);
+                    move_f32_towards(&player->pos[1], gPlayerWaterLevel[playerId] + 100.0f, 0.012f);
                     move_s16_towards(&player->unk_0CC[arg2], 0, 0.2f);
-                    if ((D_801652A0[playerId] + 40.0f) <= player->pos[1]) {
+                    if ((gPlayerWaterLevel[playerId] + 40.0f) <= player->pos[1]) {
                         player->unk_222 = 1;
                         player->unk_0CA |= 4;
                         player->alpha = ALPHA_MAX;
@@ -1865,7 +1865,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                 func_8009E088(playerId, 0xA);
             }
             if ((player->unk_0CA & 1) == 1) {
-                move_f32_towards(&player->pos[1], D_801652A0[playerId] + 40.0f, 0.02f);
+                move_f32_towards(&player->pos[1], gPlayerWaterLevel[playerId] + 40.0f, 0.02f);
                 player->alpha -= ALPHA_CHANGE_LARGE;
                 if (player->alpha <= ALPHA_CHANGE_LARGE) {
                     player->alpha = ALPHA_MIN;
@@ -1933,7 +1933,7 @@ void func_80090970(Player* player, s8 playerId, s8 arg2) {
                         pop_player_balloon(player, playerId);
                     }
                     player->unk_0CA &= ~0x0002;
-                    player->unk_0DE &= ~0x0004;
+                    player->waterInteractionFlags &= ~WATER_IN_DEEP_LIQUID_STATE;
                     if ((player->unk_0CA & 0x80) != 0x80) {
                         player->unk_0CA &= ~0x0008;
                         if ((player->topSpeed * 0.9) <= player->currentSpeed) {
@@ -2076,7 +2076,7 @@ void func_80091298(Player* player, s8 arg1) {
                 player->unk_0D4[0] = 0;
                 player->type |= PLAYER_START_SEQUENCE;
                 player->speed = 0.0f;
-                player->unk_08C = 0.0f;
+                player->kartPropulsionStrength = 0.0f;
                 player->currentSpeed = 0.0f;
                 if (arg1 == 0) {
                     D_801658BC = 1;

--- a/src/engine/objects/Thwomp.cpp
+++ b/src/engine/objects/Thwomp.cpp
@@ -54,7 +54,7 @@ OThwomp::OThwomp(s16 x, s16 z, s16 direction, f32 scale, s16 behaviour, s16 prim
     _faceDirection = direction;
     _boundingBoxSize = boundingBoxSize;
     State = (States)behaviour;
-    
+
     find_unused_obj_index(&_objectIndex);
 
     s32 objectId = _objectIndex;
@@ -650,11 +650,11 @@ void OThwomp::func_80080B28(s32 objectIndex, s32 playerId) {
                     player->unk_040 = (s16) objectIndex;
                     player->unk_046 |= 2;
                     player->soundEffects |= 0x100;
-                    func_80088FF0(player);
+                    reset_player_speed_and_velocity(player);
                 }
             }
         } else {
-            func_80088FF0(player);
+            reset_player_speed_and_velocity(player);
         }
     }
 }

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -1213,7 +1213,7 @@ void func_8002AAC0(Player* player) {
 
 void func_8002AB70(Player* player) {
     UNUSED s32 pad[2];
-    if (((player->effects & 8) != 8) && (player->unk_08C > 0.0f)) {
+    if (((player->effects & 8) != 8) && (player->kartPropulsionStrength > 0.0f)) {
         if (((player->slopeAccel / 182) < -1) && ((player->slopeAccel / 182) >= -0x14) &&
             (((player->speed / 18.0f) * 216.0f) >= 20.0f)) {
             move_f32_towards(&player->kartGravity, 500.0f, 1.0f);
@@ -1530,7 +1530,7 @@ void func_8002B9CC(Player* player, s8 arg1, UNUSED s32 arg2) {
         temp_f2 = 0;
         temp_f14 = D_8018CE10[arg1].unk_04[2];
         if (sqrtf((temp_f0 * temp_f0) + (temp_f2 * temp_f2) + (temp_f14 * temp_f14)) >= 6.5) {
-            player->unk_08C /= 4;
+            player->kartPropulsionStrength /= 4;
             player->currentSpeed /= 4;
             if (!(player->effects & 0x80) && !(player->effects & 0x40)) {
                 func_8008C73C(player, arg1);
@@ -1541,7 +1541,7 @@ void func_8002B9CC(Player* player, s8 arg1, UNUSED s32 arg2) {
         temp_f2 = gPlayerLastVelocity[arg1][1] - player->velocity[1];
         temp_f14 = gPlayerLastVelocity[arg1][2] - player->velocity[2];
         if (sqrtf((temp_f0 * temp_f0) + (temp_f2 * temp_f2) + (temp_f14 * temp_f14)) >= 4.2) {
-            player->unk_08C /= 4;
+            player->kartPropulsionStrength /= 4;
             player->currentSpeed /= 4;
             if (!(player->effects & 0x80) && !(player->effects & 0x40)) {
                 func_8008C73C(player, arg1);
@@ -1759,39 +1759,46 @@ void func_8002C17C(Player* player, s8 playerId) {
     }
 }
 
-void func_8002C4F8(Player* player, s8 arg1) {
-    D_801652A0[arg1] = get_water_level(player);
-    if (player->pos[1] <= D_801652A0[arg1]) {
-        player->unk_0DE |= 0x0002;
+void update_player_environment_and_hazard_state(Player* player, s8 playerIndex) {
+    gPlayerWaterLevel[playerIndex] = get_water_level(player);
+    if (player->pos[1] <= gPlayerWaterLevel[playerIndex]) { // Player is in water, at least partially
+        player->waterInteractionFlags |= WATER_IS_PARTIALLY_SUBMERGED;
     } else {
-        player->unk_0DE &= ~0x0002;
+        player->waterInteractionFlags &= ~WATER_IS_PARTIALLY_SUBMERGED;
     }
-    if (player->boundingBoxSize < (D_801652A0[arg1] - player->pos[1])) {
-        player->unk_0DE |= 1;
-        player->unk_0DE &= ~0x0002;
+    if (player->boundingBoxSize < (gPlayerWaterLevel[playerIndex] - player->pos[1])) {
+        // Player is fully submerged in water
+        player->waterInteractionFlags |= WATER_IS_FULLY_SUBMERGED;
+        player->waterInteractionFlags &= ~WATER_IS_PARTIALLY_SUBMERGED;
     } else {
-        player->unk_0DE &= ~0x0001;
+        // Player is not fully submerged in water, clear the flag
+        player->waterInteractionFlags &= ~WATER_IS_FULLY_SUBMERGED;
     }
-    if (player->boundingBoxSize < (D_801652A0[arg1] - player->pos[1])) {
-        if ((player->unk_0DE & 4) != 4) {
-            player->unk_0DE |= 8;
-            player->unk_0DE |= 4;
+    if (player->boundingBoxSize < (gPlayerWaterLevel[playerIndex] - player->pos[1])) {
+        // We confirm again that the player if fully submerged
+        if ((player->waterInteractionFlags & WATER_IN_DEEP_LIQUID_STATE) != WATER_IN_DEEP_LIQUID_STATE) {
+            // Set flag - it will be cleared shortly after
+            player->waterInteractionFlags |= WATER_JUST_ENTERED_DEEP_LIQUID;
+            // This flag persists longer
+            player->waterInteractionFlags |= WATER_IN_DEEP_LIQUID_STATE;
             if ((!IsKoopaTroopaBeach()) && (!IsSkyscraper()) &&
                 (!IsRainbowRoad()) && ((player->type & PLAYER_HUMAN) == PLAYER_HUMAN)) {
                 if ((IsBowsersCastle()) || (IsBigDonut())) {
-                    func_800C9060((u8) arg1, 0x1900801CU);
+                    func_800C9060((u8) playerIndex, 0x1900801CU);
                 } else {
-                    func_800C9060((u8) arg1, 0x19008008U);
+                    func_800C9060((u8) playerIndex, 0x19008008U);
                 }
             }
         }
     }
     if ((IsKoopaTroopaBeach()) || (IsSkyscraper()) ||
         (IsRainbowRoad())) {
-        player->unk_0DE &= ~0x000C;
+          // Different handling for these tracks, we just use the first two (0x0001 and 0x0002)
+          player->waterInteractionFlags &= ~(WATER_IN_DEEP_LIQUID_STATE | WATER_JUST_ENTERED_DEEP_LIQUID);
     }
-    if ((player->boundingBoxSize < (D_801652A0[arg1] - player->pos[1])) &&
+    if ((player->boundingBoxSize < (gPlayerWaterLevel[playerIndex] - player->pos[1])) &&
         (player->collision.surfaceDistance[2] >= 600.0f)) {
+        // We are fully submerged in water and far away from the surface (out of bounds?)
         player->unk_0CA |= 1;
     }
     if (player->collision.surfaceDistance[2] >= 600.0f) {
@@ -1809,7 +1816,7 @@ void func_8002C4F8(Player* player, s8 arg1) {
         func_80090778(player);
         func_80090868(player);
     }
-    func_8002C17C(player, arg1);
+    func_8002C17C(player, playerIndex);
 }
 
 void func_8002C7E4(Player* player, s8 arg1, s8 arg2) {
@@ -1908,7 +1915,7 @@ void func_8002C954(Player* player, s8 playerId, Vec3f arg2) {
     }
     if (player->effects & BOOST_EFFECT) {
         remove_boost_effect(player);
-        player->unk_08C /= 2;
+        player->kartPropulsionStrength /= 2;
     }
 }
 
@@ -2021,7 +2028,7 @@ void func_8002D028(Player* player, s8 arg1) {
         if ((player->rotation[1] < (-0x7F41)) || (player->rotation[1] > 0x7F41)) {
             player->type &= ~0x0200;
         }
-        player->unk_08C = 0;
+        player->kartPropulsionStrength = 0;
         player->speed = 0;
         player->unk_104 = 0;
         player->tyreSpeed = 0;
@@ -2032,7 +2039,7 @@ void func_8002D028(Player* player, s8 arg1) {
         player->unk_0C0 = 0;
         player->unk_078 = 0;
     } else {
-        player->unk_08C = 1200;
+        player->kartPropulsionStrength = 1200;
     }
 }
 
@@ -2121,7 +2128,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     } else {
         player->unk_044 &= 0xFFF7;
     }
-    if (((player->unk_08C <= 0.0f) && ((temp_v0_3 = player->effects, (temp_v0_3 & 1) == 1))) &&
+    if (((player->kartPropulsionStrength <= 0.0f) && ((temp_v0_3 = player->effects, (temp_v0_3 & 1) == 1))) &&
         ((temp_v0_3 & 0x20) != 0x20)) {
         sp178[2] = temp_f2_2 * 4500.0f;
     } else {
@@ -2310,7 +2317,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     player->previousSpeed = player->speed;
     player->speed = sqrtf(temp2);
 
-    if ((player->unk_08C <= 0.0f) && (player->speed <= 0.08) && (D_8018CE10[playerId].unk_04[0] == 0.0f) &&
+    if ((player->kartPropulsionStrength <= 0.0f) && (player->speed <= 0.08) && (D_8018CE10[playerId].unk_04[0] == 0.0f) &&
         (D_8018CE10[playerId].unk_04[2] == 0.0f)) {
         newVelocity[0] = newVelocity[0] + (-1 * newVelocity[0]);
         newVelocity[2] = newVelocity[2] + (-1 * newVelocity[2]);
@@ -2351,7 +2358,7 @@ void func_8002D268(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     if (player->collision.surfaceDistance[2] >= 500.0f) {
         player->unk_078 = (s16) (((s16) player->unk_078) / 2);
     }
-    func_8002C4F8(player, playerId);
+    update_player_environment_and_hazard_state(player, playerId);
 }
 
 void set_player_height(Player* player) {
@@ -2589,8 +2596,8 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
     temp = (sp54[0] * sp54[0]) + (sp54[2] * sp54[2]);
     player->previousSpeed = player->speed;
     player->speed = sqrtf(temp);
-    if ((((player->effects & 0x400) != 0x400) && (player->unk_08C <= 0) && (player->speed < 0.13)) ||
-        (((player->effects & 0x400) != 0x400) && (player->unk_08C <= 0) && (player->speed < 0.20) &&
+    if ((((player->effects & 0x400) != 0x400) && (player->kartPropulsionStrength <= 0) && (player->speed < 0.13)) ||
+        (((player->effects & 0x400) != 0x400) && (player->kartPropulsionStrength <= 0) && (player->speed < 0.20) &&
          ((player->effects & 1) == 1))) {
         sp54[0] = sp54[0] + (-1 * sp54[0]);
         sp54[2] = sp54[2] + (-1 * sp54[2]);
@@ -2613,7 +2620,7 @@ void func_8002E594(Player* player, UNUSED Camera* camera, s8 screenId, s8 player
             player->speed = gKartTopSpeedTable[player->characterId];
         }
     }
-    func_8002C4F8(player, playerId);
+    update_player_environment_and_hazard_state(player, playerId);
 }
 
 void control_cpu_movement(Player* player, UNUSED Camera* camera, s8 screenId, s8 playerId) {
@@ -2769,8 +2776,8 @@ void func_8002F730(Player* player, UNUSED Camera* camera, UNUSED s8 screenId, s8
     sqrt = (sp68[0] * sp68[0]) + (sp68[1] * sp68[1]) + (sp68[2] * sp68[2]);
     player->previousSpeed = player->speed;
     player->speed = sqrtf(sqrt);
-    if (((player->unk_08C <= 0.0f) && ((f64) player->speed < 0.13)) ||
-        ((player->unk_08C <= 0.0f) && ((f64) player->speed < 0.2) && ((player->effects & 1) == 1))) {
+    if (((player->kartPropulsionStrength <= 0.0f) && ((f64) player->speed < 0.13)) ||
+        ((player->kartPropulsionStrength <= 0.0f) && ((f64) player->speed < 0.2) && ((player->effects & 1) == 1))) {
         sp68[0] = sp68[0] + (sp68[0] * -1.0f);
         sp68[2] = sp68[2] + (sp68[2] * -1.0f);
     } else {
@@ -2960,19 +2967,19 @@ f32 func_80030150(Player* player, s8 arg1) {
                 var_f0 += -0.25;
             }
         }
-        if ((player->unk_0DE & 1) == 1) {
+        if ((player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) == WATER_IS_FULLY_SUBMERGED) {
             var_f0 += 0.3;
         } else {
-            if ((player->unk_0DE & 2) == 2) {
+            if ((player->waterInteractionFlags & WATER_IS_PARTIALLY_SUBMERGED) == WATER_IS_PARTIALLY_SUBMERGED) {
                 var_f0 += 0.15;
             }
-            if (((D_801652A0[arg1] - player->tyres[BACK_LEFT].baseHeight) >= 3.5) ||
-                ((D_801652A0[arg1] - player->tyres[BACK_RIGHT].baseHeight) >= 3.5)) {
+            if (((gPlayerWaterLevel[arg1] - player->tyres[BACK_LEFT].baseHeight) >= 3.5) ||
+                ((gPlayerWaterLevel[arg1] - player->tyres[BACK_RIGHT].baseHeight) >= 3.5)) {
                 var_f0 += 0.05;
             }
         }
         if ((player->effects & 8) != 0) {
-            move_f32_towards(&player->unk_0A0, player->unk_08C * 0.04, 0.15f);
+            move_f32_towards(&player->unk_0A0, player->kartPropulsionStrength * 0.04, 0.15f);
         } else {
             move_f32_towards(&player->unk_0A0, 0.0f, 0.1f);
         }
@@ -3006,7 +3013,7 @@ f32 func_80030150(Player* player, s8 arg1) {
         }
     }
     move_f32_towards(&player->unk_104, var_f0, gKartTurnSpeedReductionTable1[player->characterId] + 0.05);
-    var_f2 = (player->unk_08C + player->unk_0E8 + player->boostPower + player->unk_0E4) - player->unk_0A0;
+    var_f2 = (player->kartPropulsionStrength + player->unk_0E8 + player->boostPower + player->unk_0E4) - player->unk_0A0;
     if (var_f2 < 0.0f) {
         var_f2 = 0.0f;
     }
@@ -3023,8 +3030,8 @@ f32 func_80030150(Player* player, s8 arg1) {
     if (((player->effects & BOOST_EFFECT) == (BOOST_EFFECT & 0xFFFFFFFF)) ||
         ((player->effects & BOOST_RAMP_ASPHALT_EFFECT) == BOOST_RAMP_ASPHALT_EFFECT) ||
         ((player->effects & BOOST_RAMP_WOOD_EFFECT) == BOOST_RAMP_WOOD_EFFECT)) {
-        func_8002FE84(player, player->boostPower + player->unk_08C);
-        return player->boostPower + player->unk_08C;
+        func_8002FE84(player, player->boostPower + player->kartPropulsionStrength);
+        return player->boostPower + player->kartPropulsionStrength;
     }
     func_8002FE84(player, var_f2);
     return (1.0f - player->unk_104) * var_f2;
@@ -3303,7 +3310,7 @@ void player_accelerate(Player* player) {
         player->currentSpeed = player->topSpeed;
     }
     if (!((player->effects & 8)) || ((player->effects & LIGHTNING_EFFECT))) {
-        player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
+        player->kartPropulsionStrength = (player->currentSpeed * player->currentSpeed) / 25.0f;
     }
     player->unk_044 |= 0x20;
     if ((player->soundEffects * 8) < 0) {
@@ -3321,13 +3328,13 @@ void player_decelerate(Player* player, f32 speed) {
         player->currentSpeed = 0.0f;
     }
     if (player->speed < 0.2) {
-        player->unk_08C = 0.0f;
+        player->kartPropulsionStrength = 0.0f;
     }
     if (player->topSpeed <= player->currentSpeed) {
         player->currentSpeed = player->topSpeed;
     }
     if ((player->effects & 8) != 8) {
-        player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
+        player->kartPropulsionStrength = (player->currentSpeed * player->currentSpeed) / 25.0f;
     }
     player->unk_044 &= 0xFFDF;
     if ((player->soundEffects * 8) < 0) {
@@ -3590,7 +3597,7 @@ void func_80032CB0(Player* player, f32 arg1) {
         player->currentSpeed = 0.0f;
     }
     if (player->speed < 0.2) {
-        player->unk_08C = 0.0f;
+        player->kartPropulsionStrength = 0.0f;
     }
     if (player->topSpeed <= player->currentSpeed) {
         player->currentSpeed = player->topSpeed;
@@ -3894,16 +3901,16 @@ void func_80033AE0(Player* player, struct Controller* controller, s8 arg2) {
             sp2CC = 8;
         }
     }
-    if ((player->unk_0DE & 1) == 1) {
+    if ((player->waterInteractionFlags & WATER_IS_FULLY_SUBMERGED) == 1) {
         sp2C8 *= 1.5;
         sp2CC *= 1.5;
     } else {
-        if ((player->unk_0DE & 2) == 2) {
+        if ((player->waterInteractionFlags & WATER_IS_PARTIALLY_SUBMERGED) == WATER_IS_PARTIALLY_SUBMERGED) {
             sp2C8 *= 1.2;
             sp2CC *= 1.2;
         }
-        if ((((f64) (D_801652A0[arg2] - player->tyres[BACK_LEFT].baseHeight)) >= 3.5) ||
-            (((f64) (D_801652A0[arg2] - player->tyres[BACK_RIGHT].baseHeight)) >= 3.5)) {
+        if ((((f64) (gPlayerWaterLevel[arg2] - player->tyres[BACK_LEFT].baseHeight)) >= 3.5) ||
+            (((f64) (gPlayerWaterLevel[arg2] - player->tyres[BACK_RIGHT].baseHeight)) >= 3.5)) {
             sp2C8 *= 1.05;
             sp2CC *= 1.05;
         }
@@ -4542,7 +4549,7 @@ void func_80037CFC(Player* player, struct Controller* controller, s8 arg2) {
                 (controller->button & B_BUTTON)) {
                 player->currentSpeed = 140.0f;
                 player->unk_044 |= 1;
-                player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
+                player->kartPropulsionStrength = (player->currentSpeed * player->currentSpeed) / 25.0f;
                 player->unk_20C = 0.0f;
             }
             if ((func_800388B0(controller) >= -0x1D) || (!(controller->button & B_BUTTON))) {
@@ -4778,7 +4785,7 @@ void func_80038BE4(Player* player, s16 arg1) {
         player->currentSpeed = 250.0f;
     }
     player->unk_044 |= 0x20;
-    player->unk_08C = (player->currentSpeed * player->currentSpeed) / 25.0f;
+    player->kartPropulsionStrength = (player->currentSpeed * player->currentSpeed) / 25.0f;
 }
 
 void func_80038C6C(Player* player, UNUSED Camera* camera, s8 arg2, s8 playerId) {
@@ -4824,7 +4831,7 @@ void func_80038C6C(Player* player, UNUSED Camera* camera, s8 arg2, s8 playerId) 
     mtxf_translate_vec3f_mat3(sp108, player->orientationMatrix);
     spA4 += sp108[0];
     sp9C += sp108[2];
-    sp114[2] = player->unk_08C;
+    sp114[2] = player->kartPropulsionStrength;
     mtxf_translate_vec3f_mat3(sp114, player->orientationMatrix);
 
     sp88[0] = player->velocity[0];
@@ -4930,5 +4937,5 @@ void func_80038C6C(Player* player, UNUSED Camera* camera, s8 arg2, s8 playerId) 
     if (player->collision.surfaceDistance[2] >= 500.0f) {
         player->unk_078 /= 2;
     }
-    func_8002C4F8(player, playerId);
+    update_player_environment_and_hazard_state(player, playerId);
 }

--- a/src/player_controller.h
+++ b/src/player_controller.h
@@ -55,7 +55,7 @@ void func_8002BF4C(Player*, s8);
 
 void func_8002C11C(Player*);
 void func_8002C17C(Player*, s8);
-void func_8002C4F8(Player*, s8);
+void update_player_environment_and_hazard_state(Player*, s8);
 void func_8002C7E4(Player*, s8, s8);
 void func_8002C954(Player*, s8, Vec3f);
 void apply_effect(Player*, s8, s8);

--- a/src/spawn_players.c
+++ b/src/spawn_players.c
@@ -33,7 +33,7 @@ f32 D_80165230[8];
 UNUSED f32 D_80165250[8];
 s16 D_80165270[8];
 f32 D_80165280[8];
-f32 D_801652A0[8];
+f32 gPlayerWaterLevel[8];
 s32 D_801652C0[8];
 s32 D_801652E0[8];
 s16 D_80165300[8];
@@ -81,7 +81,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     s8 idx;
 
     player->type = PLAYER_INACTIVE;
-    player->unk_08C = 0;
+    player->kartPropulsionStrength = 0;
     player->characterId = characterId;
     player->unk_0B6 = 0;
     player->kartFriction = gKartFrictionTable[player->characterId];
@@ -160,13 +160,13 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->unk_07A = 0;
     player->unk_006 = 0;
     player->lapCount = -1;
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
     player->unk_090 = 0.0f;
     player->speed = 0.0f;
     player->unk_074 = 0.0f;
     player->type = playerType;
     player->unk_0CA = 0;
-    player->unk_0DE = 0;
+    player->waterInteractionFlags = WATER_NO_INTERACTION;
     player->unk_10C = 0;
     player->unk_0E2 = 0;
     player->unk_0E8 = 0.0f;
@@ -208,7 +208,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->unk_0C8 = 0;
     player->unk_0CA = 0;
     player->boostTimer = 0;
-    player->unk_0DE = 0;
+    player->waterInteractionFlags = WATER_NO_INTERACTION;
     player->unk_0E0 = 0;
     player->unk_0E2 = 0;
     player->unk_10C = 0;
@@ -242,7 +242,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     player->unk_DB4.unk14 = 0.0f;
     player->unk_084 = 0.0f;
     player->unk_088 = 0.0f;
-    player->unk_08C = 0.0f;
+    player->kartPropulsionStrength = 0.0f;
     player->unk_090 = 0.0f;
     player->speed = 0.0f;
     player->unk_098 = 0.0f;
@@ -304,7 +304,7 @@ void spawn_player(Player* player, s8 playerIndex, f32 startingRow, f32 startingC
     gPlayerLastVelocity[playerIndex][1] = 0.0f;
     gPlayerLastVelocity[playerIndex][2] = 0.0f;
     D_80165280[playerIndex] = 0.0f;
-    D_801652A0[playerIndex] = 0.0f;
+    gPlayerWaterLevel[playerIndex] = 0.0f;
     gPlayerIsThrottleActive[playerIndex] = 0;
     D_80165400[playerIndex] = 0;
     gPlayerIsBrakeActive[playerIndex] = 0;

--- a/src/spawn_players.h
+++ b/src/spawn_players.h
@@ -29,7 +29,7 @@ extern f32 D_80165210[];
 extern f32 D_80165230[];
 extern s16 D_80165270[];
 extern f32 D_80165280[];
-extern f32 D_801652A0[];
+extern f32 gPlayerWaterLevel[];
 extern s32 D_801652C0[];
 extern s32 D_801652E0[];
 extern s16 D_80165300[];


### PR DESCRIPTION
Documents `kartPropulsionStrength` and water interaction.

If you look at `update_player_environment_and_hazard_state` hopefully it is self-explanatory why it has to be a water interaction flag.