### PR TITLE
fix(shader/metal): correct noise coords and frame input in fragmentShader

### DIFF
--- a/assets/shaders/metal/default.shader.metal
+++ b/assets/shaders/metal/default.shader.metal
@@ -273,8 +273,8 @@ fragment float4 fragmentShader(ProjectedVertex in [[stage_in]], constant FrameUn
     @end
 
     @if(o_alpha && o_noise)
-        float2 coords = screenSpace.xy * noise_scale;
-        texel.w *= round(saturate(random(float3(floor(coords), noise_frame)) + texel.w - 0.5));
+        float2 coords = in.position.xy * frameUniforms.noiseScale;
+        texel.w *= round(saturate(random(float3(floor(coords), float(frameUniforms.frameCount))) + texel.w - 0.5));
     @end
 
     @if(o_alpha)


### PR DESCRIPTION
Fixes https://github.com/HarbourMasters/SpaghettiKart/issues/509

- Replace undefined `screenSpace.xy * noise_scale` with `in.position.xy * frameUniforms.noiseScale`
- Replace undefined `noise_frame` with `float(frameUniforms.frameCount)`
- This resolves build failures (undeclared identifiers, nil vertexFunction) when driving over sand

Fixes: shader compilation errors and Metal pipeline validation assertion