### PR TITLE
CPU Triple shells and overall cpu item fixes and improvments.

### DIFF
--- a/include/actor_types.h
+++ b/include/actor_types.h
@@ -305,7 +305,9 @@ typedef struct {
     /* 0x02 */ s16 flags;
     /* 0x04 */ s16 shellsAvailable;
     /* 0x06 */ s16 state;
-    /* 0x08 */ f32 unk_08;
+    /* 0x08 */ f32 unk_08;  //When the player press the button to fire a shell, this is set to 1.0f. 
+                            //Then, if it is higher than 0.0f, the game does indeed fire the next available shell. 
+                            //Not sure why a float was used, maybe aligning the struct with parent actor
     /* 0x0C */ f32 unk_0C;
     /* 0x10 */ s16 rotVelocity;
     /* 0x12 */ s16 rotAngle;

--- a/include/assets/banshee_boardwalk_data.h
+++ b/include/assets/banshee_boardwalk_data.h
@@ -248,25 +248,25 @@ static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_cheep_cheep10[] = "_
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_fish_eyes[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_fish_eyes";
 
-static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_7650[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_7650";
-
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_7650[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_7650";
 
-static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_78C0[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_78C0";
+static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_7650[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_7650";
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_78C0[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_78C0";
 
-static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_7978[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_7978";
+static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_78C0[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_78C0";
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_7978[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_7978";
 
-static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_7B38[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_7B38";
+static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_7978[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_7978";
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_7B38[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_7B38";
 
-static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_7B78[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_7B78";
+static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_7B38[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_7B38";
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_7B78[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_7B78";
+
+static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_7B78[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_7B78";
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_cheep_cheep[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_cheep_cheep";
 
@@ -295,21 +295,21 @@ static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_lights_A038[] = "__
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_texture[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_texture";
 
-static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_A850[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_A850";
-
 static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_A850[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_A850";
+
+static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_A850[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_A850";
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_A900[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_A900";
 
 static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_A900[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_A900";
 
-static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_A9B0[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_A9B0";
-
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_A9B0[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_A9B0";
 
-static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_A9C8[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_A9C8";
+static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_A9B0[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_A9B0";
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_A9C8[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_A9C8";
+
+static const ALIGN_ASSET(2) char banshee_boardwalk_data_seg6_gfx_A9C8[] = "__OTR__banshee_boardwalk_data/banshee_boardwalk_data_seg6_gfx_A9C8";
 
 static const ALIGN_ASSET(2) char d_course_banshee_boardwalk_dl_trash_bin[] = "__OTR__banshee_boardwalk_data/d_course_banshee_boardwalk_dl_trash_bin";
 

--- a/include/assets/bowsers_castle_data.h
+++ b/include/assets/bowsers_castle_data.h
@@ -257,9 +257,9 @@ static const ALIGN_ASSET(2) char d_course_bowsers_castle_thwomp_model3[] = "__OT
 
 static const ALIGN_ASSET(2) char d_course_bowsers_castle_thwomp_model4[] = "__OTR__bowsers_castle_data/d_course_bowsers_castle_thwomp_model4";
 
-static const ALIGN_ASSET(2) char bowsers_castle_data_seg6_gfx_8F38[] = "__OTR__bowsers_castle_data/bowsers_castle_data_seg6_gfx_8F38";
-
 static const ALIGN_ASSET(2) char d_course_bowsers_castle_dl_8F38[] = "__OTR__bowsers_castle_data/d_course_bowsers_castle_dl_8F38";
+
+static const ALIGN_ASSET(2) char bowsers_castle_data_seg6_gfx_8F38[] = "__OTR__bowsers_castle_data/bowsers_castle_data_seg6_gfx_8F38";
 
 static const ALIGN_ASSET(2) char d_course_bowsers_castle_dl_9078[] = "__OTR__bowsers_castle_data/d_course_bowsers_castle_dl_9078";
 

--- a/include/assets/ceremony_data.h
+++ b/include/assets/ceremony_data.h
@@ -39,13 +39,13 @@ static const ALIGN_ASSET(2) char silver_trophy_dl4[] = "__OTR__ceremony_data/sil
 
 static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_1260[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_1260";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_1418[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_1418";
-
 static const ALIGN_ASSET(2) char silver_trophy_dl5[] = "__OTR__ceremony_data/silver_trophy_dl5";
 
-static const ALIGN_ASSET(2) char silver_trophy_dl6[] = "__OTR__ceremony_data/silver_trophy_dl6";
+static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_1418[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_1418";
 
 static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_14D0[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_14D0";
+
+static const ALIGN_ASSET(2) char silver_trophy_dl6[] = "__OTR__ceremony_data/silver_trophy_dl6";
 
 static const ALIGN_ASSET(2) char ceremony_data_seg11_vtx_1580[] = "__OTR__ceremony_data/ceremony_data_seg11_vtx_1580";
 
@@ -93,9 +93,9 @@ static const ALIGN_ASSET(2) char reflection_map_silver[] = "__OTR__ceremony_data
 
 static const ALIGN_ASSET(2) char ceremony_reflection_map_gold[] = "__OTR__ceremony_data/reflection_map_gold";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_5E70[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_5E70";
-
 static const ALIGN_ASSET(2) char gold_trophy_dl[] = "__OTR__ceremony_data/gold_trophy_dl";
+
+static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_5E70[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_5E70";
 
 static const ALIGN_ASSET(2) char gold_trophy_dl2[] = "__OTR__ceremony_data/gold_trophy_dl2";
 
@@ -113,21 +113,21 @@ static const ALIGN_ASSET(2) char gold_trophy_dl5[] = "__OTR__ceremony_data/gold_
 
 static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_62C8[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_62C8";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_6518[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_6518";
-
 static const ALIGN_ASSET(2) char gold_trophy_dl6[] = "__OTR__ceremony_data/gold_trophy_dl6";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_6720[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_6720";
+static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_6518[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_6518";
 
 static const ALIGN_ASSET(2) char gold_trophy_dl7[] = "__OTR__ceremony_data/gold_trophy_dl7";
+
+static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_6720[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_6720";
 
 static const ALIGN_ASSET(2) char gold_trophy_dl8[] = "__OTR__ceremony_data/gold_trophy_dl8";
 
 static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_6880[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_6880";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_6948[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_6948";
-
 static const ALIGN_ASSET(2) char gold_trophy_dl9[] = "__OTR__ceremony_data/gold_trophy_dl9";
+
+static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_6948[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_6948";
 
 static const ALIGN_ASSET(2) char gold_trophy_dl10[] = "__OTR__ceremony_data/gold_trophy_dl10";
 
@@ -141,9 +141,9 @@ static const ALIGN_ASSET(2) char gold_trophy_dl14[] = "__OTR__ceremony_data/gold
 
 static const ALIGN_ASSET(2) char gold_trophy_dl15[] = "__OTR__ceremony_data/gold_trophy_dl15";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_lights_6BB8[] = "__OTR__ceremony_data/ceremony_data_seg11_lights_6BB8";
-
 static const ALIGN_ASSET(2) char light1[] = "__OTR__ceremony_data/light1";
+
+static const ALIGN_ASSET(2) char ceremony_data_seg11_lights_6BB8[] = "__OTR__ceremony_data/ceremony_data_seg11_lights_6BB8";
 
 static const ALIGN_ASSET(2) char gTexturePodium1[] = "__OTR__ceremony_data/texture_podium1";
 
@@ -155,9 +155,9 @@ static const ALIGN_ASSET(2) char podium_dl[] = "__OTR__ceremony_data/podium_dl";
 
 static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_7510[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_7510";
 
-static const ALIGN_ASSET(2) char podium_dl2[] = "__OTR__ceremony_data/podium_dl2";
-
 static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_75E0[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_75E0";
+
+static const ALIGN_ASSET(2) char podium_dl2[] = "__OTR__ceremony_data/podium_dl2";
 
 static const ALIGN_ASSET(2) char podium_dl3[] = "__OTR__ceremony_data/podium_dl3";
 
@@ -167,27 +167,27 @@ static const ALIGN_ASSET(2) char ceremony_data_seg11_vtx_7608[] = "__OTR__ceremo
 
 static const ALIGN_ASSET(2) char ceremony_data_seg11_vtx_7708[] = "__OTR__ceremony_data/ceremony_data_seg11_vtx_7708";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_lights_7748[] = "__OTR__ceremony_data/ceremony_data_seg11_lights_7748";
-
 static const ALIGN_ASSET(2) char light2[] = "__OTR__ceremony_data/light2";
+
+static const ALIGN_ASSET(2) char ceremony_data_seg11_lights_7748[] = "__OTR__ceremony_data/ceremony_data_seg11_lights_7748";
 
 static const ALIGN_ASSET(2) char gTexturePodium2[] = "__OTR__ceremony_data/texture_podium2";
 
-static const ALIGN_ASSET(2) char podium2_dl[] = "__OTR__ceremony_data/podium2_dl";
-
 static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_7F60[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_7F60";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_8030[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_8030";
+static const ALIGN_ASSET(2) char podium2_dl[] = "__OTR__ceremony_data/podium2_dl";
 
 static const ALIGN_ASSET(2) char podium2_dl2[] = "__OTR__ceremony_data/podium2_dl2";
+
+static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_8030[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_8030";
 
 static const ALIGN_ASSET(2) char podium2_dl3[] = "__OTR__ceremony_data/podium2_dl3";
 
 static const ALIGN_ASSET(2) char podium2_dl4[] = "__OTR__ceremony_data/podium2_dl4";
 
-static const ALIGN_ASSET(2) char light3[] = "__OTR__ceremony_data/light3";
-
 static const ALIGN_ASSET(2) char ceremony_data_seg11_lights_8058[] = "__OTR__ceremony_data/ceremony_data_seg11_lights_8058";
+
+static const ALIGN_ASSET(2) char light3[] = "__OTR__ceremony_data/light3";
 
 static const ALIGN_ASSET(2) char gTexturePodium3[] = "__OTR__ceremony_data/texture_podium3";
 
@@ -195,13 +195,13 @@ static const ALIGN_ASSET(2) char ceremony_data_seg11_vtx_8870[] = "__OTR__ceremo
 
 static const ALIGN_ASSET(2) char ceremony_data_seg11_vtx_8970[] = "__OTR__ceremony_data/ceremony_data_seg11_vtx_8970";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_89B0[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_89B0";
-
 static const ALIGN_ASSET(2) char podium3_dl[] = "__OTR__ceremony_data/podium3_dl";
 
-static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_8A80[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_8A80";
+static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_89B0[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_89B0";
 
 static const ALIGN_ASSET(2) char podium3_dl2[] = "__OTR__ceremony_data/podium3_dl2";
+
+static const ALIGN_ASSET(2) char ceremony_data_seg11_gfx_8A80[] = "__OTR__ceremony_data/ceremony_data_seg11_gfx_8A80";
 
 static const ALIGN_ASSET(2) char podium3_dl3[] = "__OTR__ceremony_data/podium3_dl3";
 

--- a/include/assets/choco_mountain_data.h
+++ b/include/assets/choco_mountain_data.h
@@ -200,9 +200,9 @@ static const ALIGN_ASSET(2) char d_course_choco_mountain_unknown_waypoints[] = "
 
 static const ALIGN_ASSET(2) char d_course_choco_mountain_track_waypoints[] = "__OTR__choco_mountain_data/d_course_choco_mountain_track_waypoints";
 
-static const ALIGN_ASSET(2) char choco_mountain_data_seg6_lights_5AE0[] = "__OTR__choco_mountain_data/choco_mountain_data_seg6_lights_5AE0";
-
 static const ALIGN_ASSET(2) char d_course_choco_mountain_light[] = "__OTR__choco_mountain_data/d_course_choco_mountain_light";
+
+static const ALIGN_ASSET(2) char choco_mountain_data_seg6_lights_5AE0[] = "__OTR__choco_mountain_data/choco_mountain_data_seg6_lights_5AE0";
 
 static const ALIGN_ASSET(2) char d_course_choco_mountain_6005AF8[] = "__OTR__choco_mountain_data/d_course_choco_mountain_6005AF8";
 

--- a/include/assets/common_data.h
+++ b/include/assets/common_data.h
@@ -51,17 +51,17 @@ static const ALIGN_ASSET(2) char D_0D001810[] = "__OTR__common_data/D_0D001810";
 
 static const ALIGN_ASSET(2) char D_0D001828[] = "__OTR__common_data/D_0D001828";
 
-static const ALIGN_ASSET(2) char D_0D001840[] = "__OTR__common_data/D_0D001840";
-
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_1840[] = "__OTR__common_data/common_data_seg13_gfx_1840";
 
-static const ALIGN_ASSET(2) char common_model_finish_post[] = "__OTR__common_data/common_model_finish_post";
+static const ALIGN_ASSET(2) char D_0D001840[] = "__OTR__common_data/D_0D001840";
 
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_1AB8[] = "__OTR__common_data/common_data_seg13_gfx_1AB8";
 
-static const ALIGN_ASSET(2) char D_0D001B68[] = "__OTR__common_data/D_0D001B68";
+static const ALIGN_ASSET(2) char common_model_finish_post[] = "__OTR__common_data/common_model_finish_post";
 
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_1B68[] = "__OTR__common_data/common_data_seg13_gfx_1B68";
+
+static const ALIGN_ASSET(2) char D_0D001B68[] = "__OTR__common_data/D_0D001B68";
 
 static const ALIGN_ASSET(2) char D_0D001B90[] = "__OTR__common_data/D_0D001B90";
 
@@ -103,9 +103,9 @@ static const ALIGN_ASSET(2) char D_0D003218[] = "__OTR__common_data/D_0D003218";
 
 static const ALIGN_ASSET(2) char D_0D003248[] = "__OTR__common_data/D_0D003248";
 
-static const ALIGN_ASSET(2) char common_data_seg13_gfx_3278[] = "__OTR__common_data/common_data_seg13_gfx_3278";
-
 static const ALIGN_ASSET(2) char D_0D003278[] = "__OTR__common_data/D_0D003278";
+
+static const ALIGN_ASSET(2) char common_data_seg13_gfx_3278[] = "__OTR__common_data/common_data_seg13_gfx_3278";
 
 static const ALIGN_ASSET(2) char D_0D003288[] = "__OTR__common_data/D_0D003288";
 
@@ -133,9 +133,9 @@ static const ALIGN_ASSET(2) char common_data_seg13_vtx_5278[] = "__OTR__common_d
 
 static const ALIGN_ASSET(2) char D_0D0052B8[] = "__OTR__common_data/D_0D0052B8";
 
-static const ALIGN_ASSET(2) char D_0D005308[] = "__OTR__common_data/D_0D005308";
-
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_5308[] = "__OTR__common_data/common_data_seg13_gfx_5308";
+
+static const ALIGN_ASSET(2) char D_0D005308[] = "__OTR__common_data/D_0D005308";
 
 static const ALIGN_ASSET(2) char D_0D005338[] = "__OTR__common_data/D_0D005338";
 
@@ -219,15 +219,15 @@ static const ALIGN_ASSET(2) char D_0D006950[] = "__OTR__common_data/D_0D006950";
 
 static const ALIGN_ASSET(2) char D_0D006968[] = "__OTR__common_data/D_0D006968";
 
-static const ALIGN_ASSET(2) char common_data_seg13_gfx_6980[] = "__OTR__common_data/common_data_seg13_gfx_6980";
-
 static const ALIGN_ASSET(2) char D_0D006980[] = "__OTR__common_data/D_0D006980";
+
+static const ALIGN_ASSET(2) char common_data_seg13_gfx_6980[] = "__OTR__common_data/common_data_seg13_gfx_6980";
 
 static const ALIGN_ASSET(2) char D_0D006998[] = "__OTR__common_data/D_0D006998";
 
-static const ALIGN_ASSET(2) char common_data_seg13_gfx_69B0[] = "__OTR__common_data/common_data_seg13_gfx_69B0";
-
 static const ALIGN_ASSET(2) char D_0D0069B0[] = "__OTR__common_data/D_0D0069B0";
+
+static const ALIGN_ASSET(2) char common_data_seg13_gfx_69B0[] = "__OTR__common_data/common_data_seg13_gfx_69B0";
 
 static const ALIGN_ASSET(2) char D_0D0069C8[] = "__OTR__common_data/D_0D0069C8";
 
@@ -253,9 +253,9 @@ static const ALIGN_ASSET(2) char common_texture_debug_font[] = "__OTR__common_da
 
 static const ALIGN_ASSET(2) char D_0D0076F8[] = "__OTR__common_data/D_0D0076F8";
 
-static const ALIGN_ASSET(2) char common_data_seg13_gfx_7780[] = "__OTR__common_data/common_data_seg13_gfx_7780";
-
 static const ALIGN_ASSET(2) char D_0D007780[] = "__OTR__common_data/D_0D007780";
+
+static const ALIGN_ASSET(2) char common_data_seg13_gfx_7780[] = "__OTR__common_data/common_data_seg13_gfx_7780";
 
 static const ALIGN_ASSET(2) char D_0D0077A0[] = "__OTR__common_data/D_0D0077A0";
 
@@ -273,9 +273,9 @@ static const ALIGN_ASSET(2) char D_0D0078A0[] = "__OTR__common_data/D_0D0078A0";
 
 static const ALIGN_ASSET(2) char D_0D0078D0[] = "__OTR__common_data/D_0D0078D0";
 
-static const ALIGN_ASSET(2) char D_0D0078F8[] = "__OTR__common_data/D_0D0078F8";
-
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_78F8[] = "__OTR__common_data/common_data_seg13_gfx_78F8";
+
+static const ALIGN_ASSET(2) char D_0D0078F8[] = "__OTR__common_data/D_0D0078F8";
 
 static const ALIGN_ASSET(2) char D_0D007928[] = "__OTR__common_data/D_0D007928";
 
@@ -353,13 +353,13 @@ static const ALIGN_ASSET(2) char D_0D007E98[] = "__OTR__common_data/D_0D007E98";
 
 static const ALIGN_ASSET(2) char D_0D007EB8[] = "__OTR__common_data/D_0D007EB8";
 
-static const ALIGN_ASSET(2) char D_0D007ED8[] = "__OTR__common_data/D_0D007ED8";
-
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_7ED8[] = "__OTR__common_data/common_data_seg13_gfx_7ED8";
 
-static const ALIGN_ASSET(2) char common_data_seg13_gfx_7EF8[] = "__OTR__common_data/common_data_seg13_gfx_7EF8";
+static const ALIGN_ASSET(2) char D_0D007ED8[] = "__OTR__common_data/D_0D007ED8";
 
 static const ALIGN_ASSET(2) char D_0D007EF8[] = "__OTR__common_data/D_0D007EF8";
+
+static const ALIGN_ASSET(2) char common_data_seg13_gfx_7EF8[] = "__OTR__common_data/common_data_seg13_gfx_7EF8";
 
 static const ALIGN_ASSET(2) char D_0D007F18[] = "__OTR__common_data/D_0D007F18";
 
@@ -371,17 +371,17 @@ static const ALIGN_ASSET(2) char D_0D007F78[] = "__OTR__common_data/D_0D007F78";
 
 static const ALIGN_ASSET(2) char D_0D007F98[] = "__OTR__common_data/D_0D007F98";
 
-static const ALIGN_ASSET(2) char D_0D007FB8[] = "__OTR__common_data/D_0D007FB8";
-
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_7FB8[] = "__OTR__common_data/common_data_seg13_gfx_7FB8";
+
+static const ALIGN_ASSET(2) char D_0D007FB8[] = "__OTR__common_data/D_0D007FB8";
 
 static const ALIGN_ASSET(2) char D_0D007FE0[] = "__OTR__common_data/D_0D007FE0";
 
 static const ALIGN_ASSET(2) char D_0D008000[] = "__OTR__common_data/D_0D008000";
 
-static const ALIGN_ASSET(2) char D_0D008020[] = "__OTR__common_data/D_0D008020";
-
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_8020[] = "__OTR__common_data/common_data_seg13_gfx_8020";
+
+static const ALIGN_ASSET(2) char D_0D008020[] = "__OTR__common_data/D_0D008020";
 
 static const ALIGN_ASSET(2) char D_0D008040[] = "__OTR__common_data/D_0D008040";
 
@@ -403,9 +403,9 @@ static const ALIGN_ASSET(2) char D_0D008BF8[] = "__OTR__common_data/D_0D008BF8";
 
 static const ALIGN_ASSET(2) char D_0D008C38[] = "__OTR__common_data/D_0D008C38";
 
-static const ALIGN_ASSET(2) char common_square_plain_render[] = "__OTR__common_data/common_square_plain_render";
-
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_8C78[] = "__OTR__common_data/common_data_seg13_gfx_8C78";
+
+static const ALIGN_ASSET(2) char common_square_plain_render[] = "__OTR__common_data/common_square_plain_render";
 
 static const ALIGN_ASSET(2) char D_0D008C90[] = "__OTR__common_data/D_0D008C90";
 
@@ -415,9 +415,9 @@ static const ALIGN_ASSET(2) char D_0D008D10[] = "__OTR__common_data/D_0D008D10";
 
 static const ALIGN_ASSET(2) char D_0D008D58[] = "__OTR__common_data/D_0D008D58";
 
-static const ALIGN_ASSET(2) char D_0D008DA0[] = "__OTR__common_data/D_0D008DA0";
-
 static const ALIGN_ASSET(2) char common_data_seg13_gfx_8DA0[] = "__OTR__common_data/common_data_seg13_gfx_8DA0";
+
+static const ALIGN_ASSET(2) char D_0D008DA0[] = "__OTR__common_data/D_0D008DA0";
 
 static const ALIGN_ASSET(2) char D_0D008DB8[] = "__OTR__common_data/D_0D008DB8";
 
@@ -846,7 +846,9 @@ static const char* common_texture_minimap_kart_character[] = {
 	common_texture_minimap_kart_bowser,
 };
 
-static const ALIGN_ASSET(2) char common_texture_minimap_bowser[] = "__OTR__common_data/common_texture_minimap_bowser";
+static const ALIGN_ASSET(2) char common_texture_minimap_dk[] = "__OTR__common_data/common_texture_minimap_dk";
+
+static const ALIGN_ASSET(2) char common_texture_minimap_peach[] = "__OTR__common_data/common_texture_minimap_peach";
 
 static const ALIGN_ASSET(2) char common_texture_minimap_progress_dot[] = "__OTR__common_data/common_texture_minimap_progress_dot";
 
@@ -856,11 +858,9 @@ static const ALIGN_ASSET(2) char common_texture_minimap_luigi[] = "__OTR__common
 
 static const ALIGN_ASSET(2) char common_texture_minimap_yoshi[] = "__OTR__common_data/common_texture_minimap_yoshi";
 
+static const ALIGN_ASSET(2) char common_texture_minimap_bowser[] = "__OTR__common_data/common_texture_minimap_bowser";
+
 static const ALIGN_ASSET(2) char common_texture_minimap_toad[] = "__OTR__common_data/common_texture_minimap_toad";
 
-static const ALIGN_ASSET(2) char common_texture_minimap_dk[] = "__OTR__common_data/common_texture_minimap_dk";
-
 static const ALIGN_ASSET(2) char common_texture_minimap_wario[] = "__OTR__common_data/common_texture_minimap_wario";
-
-static const ALIGN_ASSET(2) char common_texture_minimap_peach[] = "__OTR__common_data/common_texture_minimap_peach";
 

--- a/include/assets/dks_jungle_parkway_data.h
+++ b/include/assets/dks_jungle_parkway_data.h
@@ -4,9 +4,9 @@
 #include <libultra/gbi.h>
 #include <align_asset_macro.h>
 
-static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_0[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_0";
-
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_0[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_0";
+
+static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_0[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_0";
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_20[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_20";
 
@@ -252,9 +252,9 @@ static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_paddle_boat_model14
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_paddle_boat_model15[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_paddle_boat_model15";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_unknown_light1[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_unknown_light1";
-
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_lights_9DE8[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_lights_9DE8";
+
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_unknown_light1[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_unknown_light1";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_lights_9E00[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_lights_9E00";
 
@@ -264,9 +264,9 @@ static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_lights_9E18[] = "_
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_unknown_light3[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_unknown_light3";
 
-static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_lights_9E30[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_lights_9E30";
-
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_unknown_light4[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_unknown_light4";
+
+static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_lights_9E30[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_lights_9E30";
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_mario_sign[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_mario_sign";
 
@@ -282,31 +282,31 @@ static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_DE48[] = "__OTR_
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_DE48[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_DE48";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_DF30[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_DF30";
-
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_DF30[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_DF30";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E030[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E030";
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_DF30[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_DF30";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E030[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E030";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E048[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E048";
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E030[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E030";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E048[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E048";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_railings_dl[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_railings_dl";
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E048[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E048";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E068[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E068";
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_railings_dl[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_railings_dl";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E068[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E068";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E150[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E150";
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E068[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E068";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E150[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E150";
 
-static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E238[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E238";
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E150[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E150";
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E238[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E238";
+
+static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E238[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E238";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E250[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E250";
 
@@ -316,17 +316,17 @@ static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E310[] = "__OTR_
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E310[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E310";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E320[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E320";
-
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E320[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E320";
 
-static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E578[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E578";
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E320[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E320";
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E578[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E578";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E588[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E588";
+static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E578[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E578";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E588[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E588";
+
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E588[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E588";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E618[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E618";
 
@@ -336,17 +336,17 @@ static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E628[] = "__OT
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E628[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E628";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E688[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E688";
-
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E688[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E688";
+
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E688[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E688";
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E6E8[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E6E8";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E6E8[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E6E8";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E700[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E700";
-
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_E700[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_E700";
+
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_E700[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_E700";
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_boat_dl[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_boat_dl";
 
@@ -364,13 +364,13 @@ static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_FAE0[] = "__OTR_
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_FAE0[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_FAE0";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_FC08[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_FC08";
-
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_FC08[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_FC08";
 
-static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_FC18[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_FC18";
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_FC08[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_FC08";
 
 static const ALIGN_ASSET(2) char dks_jungle_parkway_data_seg6_gfx_FC18[] = "__OTR__dks_jungle_parkway_data/dks_jungle_parkway_data_seg6_gfx_FC18";
+
+static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_dl_FC18[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_dl_FC18";
 
 static const ALIGN_ASSET(2) char d_course_dks_jungle_parkway_paddle_wheel_dl[] = "__OTR__dks_jungle_parkway_data/d_course_dks_jungle_parkway_paddle_wheel_dl";
 

--- a/include/assets/kalimari_desert_data.h
+++ b/include/assets/kalimari_desert_data.h
@@ -296,17 +296,17 @@ static const ALIGN_ASSET(2) char d_course_kalimari_desert_unknown_lod2_locomotiv
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_unknown_lod2_locomotive_model21[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_unknown_lod2_locomotive_model21";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1B7C0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1B7C0";
-
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1B7C0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1B7C0";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1B850[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1B850";
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1B7C0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1B7C0";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1B850[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1B850";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1B950[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1B950";
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1B850[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1B850";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1B950[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1B950";
+
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1B950[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1B950";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1B968[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1B968";
 
@@ -334,9 +334,9 @@ static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1BF90[] = "__OTR_
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1BF90[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1BF90";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1C0B0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1C0B0";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1C0B0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1C0B0";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1C0B0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1C0B0";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1C0E0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1C0E0";
 
@@ -404,13 +404,13 @@ static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1D450[] = "__OTR__k
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1D450[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1D450";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1D540[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1D540";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1D540[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1D540";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1D598[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1D598";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1D540[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1D540";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1D598[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1D598";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1D598[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1D598";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1D630[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1D630";
 
@@ -454,17 +454,17 @@ static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E2C8[] = "__OTR_
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E2C8[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1E2C8";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E358[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1E358";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E358[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1E358";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E458[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1E458";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E358[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1E358";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E458[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1E458";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E470[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1E470";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E458[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1E458";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E470[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1E470";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E470[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1E470";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E480[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1E480";
 
@@ -484,9 +484,9 @@ static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E800[] = "__OTR__k
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E800[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1E800";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E858[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1E858";
-
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1E858[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1E858";
+
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E858[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1E858";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1E8D0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1E8D0";
 
@@ -524,9 +524,9 @@ static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F1F8[] = "__OTR__k
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F1F8[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F1F8";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F218[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F218";
-
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F218[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F218";
+
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F218[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F218";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F228[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F228";
 
@@ -536,17 +536,17 @@ static const ALIGN_ASSET(2) char d_course_kalimari_desert_unknown_lod1_tender_mo
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_unknown_lod1_tender_model2[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_unknown_lod1_tender_model2";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F570[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F570";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F570[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F570";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F570[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F570";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F5E0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F5E0";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F5E0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F5E0";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F6E0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F6E0";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F6E0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F6E0";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F6E0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F6E0";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F6F8[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F6F8";
 
@@ -566,13 +566,13 @@ static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F988[] = "__OTR_
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F988[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F988";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F9D8[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F9D8";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1F9D8[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1F9D8";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1FAD0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1FAD0";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1F9D8[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1F9D8";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1FAD0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1FAD0";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_1FAD0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_1FAD0";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_1FAE8[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_1FAE8";
 
@@ -604,25 +604,25 @@ static const ALIGN_ASSET(2) char d_course_kalimari_desert_unknown_lod2_carriage_
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_unknown_lod2_carriage_chassis_model10[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_unknown_lod2_carriage_chassis_model10";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20578[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_20578";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_20578[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_20578";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_20610[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_20610";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20578[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_20578";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20610[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_20610";
+
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_20610[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_20610";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_20620[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_20620";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20620[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_20620";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20630[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_20630";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_20630[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_20630";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20688[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_20688";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20630[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_20630";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_20688[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_20688";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20688[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_20688";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_208A0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_208A0";
 
@@ -636,13 +636,13 @@ static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_20980[] = "__OTR_
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_20980[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_20980";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_209C8[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_209C8";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_209C8[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_209C8";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_209F8[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_209F8";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_209C8[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_209C8";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_209F8[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_209F8";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_209F8[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_209F8";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_20A08[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_20A08";
 
@@ -670,9 +670,9 @@ static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21178[] = "__OTR__k
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21178[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21178";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21200[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21200";
-
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21200[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21200";
+
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21200[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21200";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21210[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21210";
 
@@ -680,29 +680,29 @@ static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21210[] = "__OTR_
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21220[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21220";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21238[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21238";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21238[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21238";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21238[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21238";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21288[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21288";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21288[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21288";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21480[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21480";
-
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21480[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21480";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_214D0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_214D0";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21480[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21480";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_214D0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_214D0";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21518[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21518";
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_214D0[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_214D0";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21518[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21518";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21540[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21540";
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21518[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21518";
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21540[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21540";
+
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21540[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21540";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21550[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21550";
 
@@ -744,17 +744,17 @@ static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21BC0[] = "__OTR__k
 
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21BC0[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21BC0";
 
-static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21C10[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21C10";
-
 static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21C10[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21C10";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21C58[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21C58";
+static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21C10[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21C10";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21C58[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21C58";
 
-static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21C80[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21C80";
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21C58[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21C58";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21C80[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21C80";
+
+static const ALIGN_ASSET(2) char kalimari_desert_data_seg6_gfx_21C80[] = "__OTR__kalimari_desert_data/kalimari_desert_data_seg6_gfx_21C80";
 
 static const ALIGN_ASSET(2) char d_course_kalimari_desert_dl_21C90[] = "__OTR__kalimari_desert_data/d_course_kalimari_desert_dl_21C90";
 

--- a/include/assets/koopa_troopa_beach_data.h
+++ b/include/assets/koopa_troopa_beach_data.h
@@ -670,9 +670,9 @@ static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_bird_wing_3_model[]
 
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_16990[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_16990";
 
-static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_lights_16B78[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_lights_16B78";
-
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_light2[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_light2";
+
+static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_lights_16B78[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_lights_16B78";
 
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_tree_model[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_tree_model";
 
@@ -686,15 +686,15 @@ static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_18520[] = "__OTR
 
 static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18520[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_18520";
 
-static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_185E8[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_185E8";
-
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_185E8[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_185E8";
+
+static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_185E8[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_185E8";
 
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_tree_top1[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_tree_top1";
 
-static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18608[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_18608";
-
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_18608[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_18608";
+
+static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18608[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_18608";
 
 static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_186A8[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_186A8";
 
@@ -714,9 +714,9 @@ static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_18870[] = "__OTR
 
 static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18870[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_18870";
 
-static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18938[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_18938";
-
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_18938[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_18938";
+
+static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18938[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_18938";
 
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_tree_top2[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_tree_top2";
 
@@ -724,9 +724,9 @@ static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18958[] = "__O
 
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_18958[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_18958";
 
-static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_189F8[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_189F8";
-
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_189F8[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_189F8";
+
+static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_189F8[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_189F8";
 
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_tree_trunk2[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_tree_trunk2";
 
@@ -752,9 +752,9 @@ static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18CA8[] = "__O
 
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_18CA8[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_18CA8";
 
-static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18D48[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_18D48";
-
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_18D48[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_18D48";
+
+static const ALIGN_ASSET(2) char koopa_troopa_beach_data_seg6_gfx_18D48[] = "__OTR__koopa_troopa_beach_data/koopa_troopa_beach_data_seg6_gfx_18D48";
 
 static const ALIGN_ASSET(2) char d_course_koopa_troopa_beach_dl_tree_trunk3[] = "__OTR__koopa_troopa_beach_data/d_course_koopa_troopa_beach_dl_tree_trunk3";
 

--- a/include/assets/luigi_raceway_data.h
+++ b/include/assets/luigi_raceway_data.h
@@ -260,9 +260,9 @@ static const ALIGN_ASSET(2) char d_course_luigi_raceway_unknown_model4[] = "__OT
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_unknown_model5[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_unknown_model5";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_lights_C3A0[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_lights_C3A0";
-
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_light1[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_light1";
+
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_lights_C3A0[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_lights_C3A0";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_basket_model_lod1[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_basket_model_lod1";
 
@@ -280,9 +280,9 @@ static const ALIGN_ASSET(2) char d_course_luigi_raceway_balloon_basket[] = "__OT
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_balloon_rope[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_balloon_rope";
 
-static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F588[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F588";
-
 static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F588[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F588";
+
+static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F588[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F588";
 
 static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F630[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F630";
 
@@ -294,21 +294,21 @@ static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F640[] = "__OTR__luig
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F650[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F650";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F660[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F660";
-
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F660[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F660";
+
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F660[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F660";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F718[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F718";
 
 static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F718[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F718";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F728[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F728";
-
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F728[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F728";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F938[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F938";
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F728[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F728";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F938[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F938";
+
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F938[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F938";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F948[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F948";
 
@@ -316,35 +316,35 @@ static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F948[] = "__OTR__lu
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F960[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F960";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F970[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F970";
-
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_F970[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_F970";
+
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_F970[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_F970";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_FA00[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_FA00";
 
 static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FA00[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FA00";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FA10[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FA10";
-
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_FA10[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_FA10";
+
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FA10[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FA10";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_FA20[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_FA20";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FA30[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FA30";
-
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_FA30[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_FA30";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FB10[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FB10";
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FA30[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FA30";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_FB10[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_FB10";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FB20[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FB20";
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FB10[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FB10";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_FB20[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_FB20";
 
-static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FBB8[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FBB8";
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FB20[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FB20";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_FBB8[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_FBB8";
+
+static const ALIGN_ASSET(2) char luigi_raceway_data_seg6_gfx_FBB8[] = "__OTR__luigi_raceway_data/luigi_raceway_data_seg6_gfx_FBB8";
 
 static const ALIGN_ASSET(2) char d_course_luigi_raceway_dl_FBC8[] = "__OTR__luigi_raceway_data/d_course_luigi_raceway_dl_FBC8";
 

--- a/include/assets/mario_raceway_data.h
+++ b/include/assets/mario_raceway_data.h
@@ -174,9 +174,9 @@ static const ALIGN_ASSET(2) char d_course_mario_sign_left[] = "__OTR__mario_race
 
 static const ALIGN_ASSET(2) char d_course_mario_sign_right[] = "__OTR__mario_raceway_data/d_course_mario_sign_right";
 
-static const ALIGN_ASSET(2) char d_course_mario_raceway_dl_9068[] = "__OTR__mario_raceway_data/d_course_mario_raceway_dl_9068";
-
 static const ALIGN_ASSET(2) char mario_raceway_data_seg6_gfx_9068[] = "__OTR__mario_raceway_data/mario_raceway_data_seg6_gfx_9068";
+
+static const ALIGN_ASSET(2) char d_course_mario_raceway_dl_9068[] = "__OTR__mario_raceway_data/d_course_mario_raceway_dl_9068";
 
 static const ALIGN_ASSET(2) char mario_raceway_data_seg6_gfx_90B0[] = "__OTR__mario_raceway_data/mario_raceway_data_seg6_gfx_90B0";
 
@@ -194,9 +194,9 @@ static const ALIGN_ASSET(2) char mario_raceway_data_seg6_gfx_9250[] = "__OTR__ma
 
 static const ALIGN_ASSET(2) char d_course_mario_raceway_dl_9250[] = "__OTR__mario_raceway_data/d_course_mario_raceway_dl_9250";
 
-static const ALIGN_ASSET(2) char mario_raceway_data_seg6_gfx_9310[] = "__OTR__mario_raceway_data/mario_raceway_data_seg6_gfx_9310";
-
 static const ALIGN_ASSET(2) char d_course_mario_raceway_dl_9310[] = "__OTR__mario_raceway_data/d_course_mario_raceway_dl_9310";
+
+static const ALIGN_ASSET(2) char mario_raceway_data_seg6_gfx_9310[] = "__OTR__mario_raceway_data/mario_raceway_data_seg6_gfx_9310";
 
 static const ALIGN_ASSET(2) char d_course_mario_raceway_dl_sign[] = "__OTR__mario_raceway_data/d_course_mario_raceway_dl_sign";
 

--- a/include/assets/moo_moo_farm_data.h
+++ b/include/assets/moo_moo_farm_data.h
@@ -12,9 +12,9 @@ static const ALIGN_ASSET(2) char d_course_moo_moo_farm_dl_30[] = "__OTR__moo_moo
 
 static const ALIGN_ASSET(2) char moo_moo_farm_data_seg6_gfx_30[] = "__OTR__moo_moo_farm_data/moo_moo_farm_data_seg6_gfx_30";
 
-static const ALIGN_ASSET(2) char moo_moo_farm_data_seg6_gfx_48[] = "__OTR__moo_moo_farm_data/moo_moo_farm_data_seg6_gfx_48";
-
 static const ALIGN_ASSET(2) char d_course_moo_moo_farm_dl_48[] = "__OTR__moo_moo_farm_data/d_course_moo_moo_farm_dl_48";
+
+static const ALIGN_ASSET(2) char moo_moo_farm_data_seg6_gfx_48[] = "__OTR__moo_moo_farm_data/moo_moo_farm_data_seg6_gfx_48";
 
 static const ALIGN_ASSET(2) char d_course_moo_moo_farm_dl_60[] = "__OTR__moo_moo_farm_data/d_course_moo_moo_farm_dl_60";
 

--- a/include/assets/other_textures.h
+++ b/include/assets/other_textures.h
@@ -573,9 +573,9 @@ static const ALIGN_ASSET(2) char gTexture68DEC0[] = "__OTR__other_textures/textu
 
 static const ALIGN_ASSET(2) char gTexture68E2D0[] = "__OTR__other_textures/texture_68E2D0";
 
-static const ALIGN_ASSET(2) char texture_red_shell_0[] = "__OTR__other_textures/texture_red_shell_0";
-
 static const ALIGN_ASSET(2) char texture_green_shell_0[] = "__OTR__other_textures/texture_green_shell_0";
+
+static const ALIGN_ASSET(2) char texture_red_shell_0[] = "__OTR__other_textures/texture_red_shell_0";
 
 static const ALIGN_ASSET(2) char texture_green_shell_1[] = "__OTR__other_textures/texture_green_shell_1";
 
@@ -589,9 +589,9 @@ static const ALIGN_ASSET(2) char texture_green_shell_3[] = "__OTR__other_texture
 
 static const ALIGN_ASSET(2) char texture_red_shell_3[] = "__OTR__other_textures/texture_red_shell_3";
 
-static const ALIGN_ASSET(2) char texture_red_shell_4[] = "__OTR__other_textures/texture_red_shell_4";
-
 static const ALIGN_ASSET(2) char texture_green_shell_4[] = "__OTR__other_textures/texture_green_shell_4";
+
+static const ALIGN_ASSET(2) char texture_red_shell_4[] = "__OTR__other_textures/texture_red_shell_4";
 
 static const ALIGN_ASSET(2) char texture_green_shell_5[] = "__OTR__other_textures/texture_green_shell_5";
 

--- a/include/assets/rainbow_road_data.h
+++ b/include/assets/rainbow_road_data.h
@@ -190,23 +190,23 @@ static const char* d_course_rainbow_road_static_tluts[] = {
 	gTLUTRainbowRoadNeonToad,
 };
 
-static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mushroom1[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mushroom1";
+static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mushroom5[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mushroom5";
 
 static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mushroom2[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mushroom2";
 
-static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mushroom3[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mushroom3";
-
 static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mushroom4[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mushroom4";
 
-static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mushroom5[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mushroom5";
+static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mushroom1[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mushroom1";
 
-static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mario1[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mario1";
+static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mushroom3[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mushroom3";
 
-static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mario2[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mario2";
+static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mario4[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mario4";
 
 static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mario3[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mario3";
 
-static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mario4[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mario4";
+static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mario2[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mario2";
+
+static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mario1[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mario1";
 
 static const ALIGN_ASSET(2) char d_course_rainbow_road_neon_mario5[] = "__OTR__rainbow_road_data/d_course_rainbow_road_neon_mario5";
 

--- a/include/assets/sherbet_land_data.h
+++ b/include/assets/sherbet_land_data.h
@@ -318,9 +318,9 @@ static const ALIGN_ASSET(2) char d_course_sherbet_land_dl_ice_block[] = "__OTR__
 
 static const ALIGN_ASSET(2) char d_course_sherbet_land_dl_7228[] = "__OTR__sherbet_land_data/d_course_sherbet_land_dl_7228";
 
-static const ALIGN_ASSET(2) char sherbet_land_data_seg6_lights_7240[] = "__OTR__sherbet_land_data/sherbet_land_data_seg6_lights_7240";
-
 static const ALIGN_ASSET(2) char d_course_sherbet_land_light1[] = "__OTR__sherbet_land_data/d_course_sherbet_land_light1";
+
+static const ALIGN_ASSET(2) char sherbet_land_data_seg6_lights_7240[] = "__OTR__sherbet_land_data/sherbet_land_data_seg6_lights_7240";
 
 static const ALIGN_ASSET(2) char sherbet_land_data_seg6_lights_7258[] = "__OTR__sherbet_land_data/sherbet_land_data_seg6_lights_7258";
 
@@ -350,9 +350,9 @@ static const ALIGN_ASSET(2) char d_course_sherbet_land_penguin_eye[] = "__OTR__s
 
 static const ALIGN_ASSET(2) char d_course_sherbet_land_penguin_eyes_model[] = "__OTR__sherbet_land_data/d_course_sherbet_land_penguin_eyes_model";
 
-static const ALIGN_ASSET(2) char sherbet_land_data_seg6_gfx_8368[] = "__OTR__sherbet_land_data/sherbet_land_data_seg6_gfx_8368";
-
 static const ALIGN_ASSET(2) char d_course_sherbet_land_dl_8368[] = "__OTR__sherbet_land_data/d_course_sherbet_land_dl_8368";
+
+static const ALIGN_ASSET(2) char sherbet_land_data_seg6_gfx_8368[] = "__OTR__sherbet_land_data/sherbet_land_data_seg6_gfx_8368";
 
 static const ALIGN_ASSET(2) char d_course_sherbet_land_penguin_nose_model[] = "__OTR__sherbet_land_data/d_course_sherbet_land_penguin_nose_model";
 
@@ -364,9 +364,9 @@ static const ALIGN_ASSET(2) char d_course_sherbet_land_penguin_head_model1[] = "
 
 static const ALIGN_ASSET(2) char d_course_sherbet_land_penguin_head_model2[] = "__OTR__sherbet_land_data/d_course_sherbet_land_penguin_head_model2";
 
-static const ALIGN_ASSET(2) char sherbet_land_data_seg6_gfx_85B0[] = "__OTR__sherbet_land_data/sherbet_land_data_seg6_gfx_85B0";
-
 static const ALIGN_ASSET(2) char d_course_sherbet_land_dl_85B0[] = "__OTR__sherbet_land_data/d_course_sherbet_land_dl_85B0";
+
+static const ALIGN_ASSET(2) char sherbet_land_data_seg6_gfx_85B0[] = "__OTR__sherbet_land_data/sherbet_land_data_seg6_gfx_85B0";
 
 static const ALIGN_ASSET(2) char d_course_sherbet_land_penguin_arms_model[] = "__OTR__sherbet_land_data/d_course_sherbet_land_penguin_arms_model";
 

--- a/include/assets/startup_logo.h
+++ b/include/assets/startup_logo.h
@@ -74,17 +74,17 @@ static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_2FF0[] = "__OTR__startup_
 
 static const ALIGN_ASSET(2) char startup_logo_dl5[] = "__OTR__startup_logo/dl5";
 
-static const ALIGN_ASSET(2) char startup_logo_dl6[] = "__OTR__startup_logo/dl6";
-
 static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_3180[] = "__OTR__startup_logo/startup_logo_seg6_gfx_3180";
 
-static const ALIGN_ASSET(2) char startup_logo_dl7[] = "__OTR__startup_logo/dl7";
+static const ALIGN_ASSET(2) char startup_logo_dl6[] = "__OTR__startup_logo/dl6";
 
 static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_3308[] = "__OTR__startup_logo/startup_logo_seg6_gfx_3308";
 
-static const ALIGN_ASSET(2) char startup_logo_dl8[] = "__OTR__startup_logo/dl8";
+static const ALIGN_ASSET(2) char startup_logo_dl7[] = "__OTR__startup_logo/dl7";
 
 static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_33D8[] = "__OTR__startup_logo/startup_logo_seg6_gfx_33D8";
+
+static const ALIGN_ASSET(2) char startup_logo_dl8[] = "__OTR__startup_logo/dl8";
 
 static const ALIGN_ASSET(2) char startup_logo_seg6_vtx_3538[] = "__OTR__startup_logo/startup_logo_seg6_vtx_3538";
 
@@ -164,9 +164,9 @@ static const ALIGN_ASSET(2) char startup_logo_seg6_vtx_75A8[] = "__OTR__startup_
 
 static const ALIGN_ASSET(2) char startup_logo_seg6_vtx_77A8[] = "__OTR__startup_logo/startup_logo_seg6_vtx_77A8";
 
-static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_7988[] = "__OTR__startup_logo/startup_logo_seg6_gfx_7988";
-
 static const ALIGN_ASSET(2) char startup_logo_dl9[] = "__OTR__startup_logo/dl9";
+
+static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_7988[] = "__OTR__startup_logo/startup_logo_seg6_gfx_7988";
 
 static const ALIGN_ASSET(2) char startup_logo_dl10[] = "__OTR__startup_logo/dl10";
 
@@ -180,37 +180,37 @@ static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_7E50[] = "__OTR__startup_
 
 static const ALIGN_ASSET(2) char startup_logo_dl12[] = "__OTR__startup_logo/dl12";
 
-static const ALIGN_ASSET(2) char startup_logo_dl13[] = "__OTR__startup_logo/dl13";
-
 static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_7E90[] = "__OTR__startup_logo/startup_logo_seg6_gfx_7E90";
 
-static const ALIGN_ASSET(2) char startup_logo_dl14[] = "__OTR__startup_logo/dl14";
+static const ALIGN_ASSET(2) char startup_logo_dl13[] = "__OTR__startup_logo/dl13";
 
 static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_7ED0[] = "__OTR__startup_logo/startup_logo_seg6_gfx_7ED0";
 
-static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_7F88[] = "__OTR__startup_logo/startup_logo_seg6_gfx_7F88";
+static const ALIGN_ASSET(2) char startup_logo_dl14[] = "__OTR__startup_logo/dl14";
 
 static const ALIGN_ASSET(2) char startup_logo_dl15[] = "__OTR__startup_logo/dl15";
 
-static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_80F0[] = "__OTR__startup_logo/startup_logo_seg6_gfx_80F0";
+static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_7F88[] = "__OTR__startup_logo/startup_logo_seg6_gfx_7F88";
 
 static const ALIGN_ASSET(2) char startup_logo_dl16[] = "__OTR__startup_logo/dl16";
 
-static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_8250[] = "__OTR__startup_logo/startup_logo_seg6_gfx_8250";
+static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_80F0[] = "__OTR__startup_logo/startup_logo_seg6_gfx_80F0";
 
 static const ALIGN_ASSET(2) char startup_logo_dl17[] = "__OTR__startup_logo/dl17";
 
-static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_83C8[] = "__OTR__startup_logo/startup_logo_seg6_gfx_83C8";
+static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_8250[] = "__OTR__startup_logo/startup_logo_seg6_gfx_8250";
 
 static const ALIGN_ASSET(2) char startup_logo_dl18[] = "__OTR__startup_logo/dl18";
 
-static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_8548[] = "__OTR__startup_logo/startup_logo_seg6_gfx_8548";
+static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_83C8[] = "__OTR__startup_logo/startup_logo_seg6_gfx_83C8";
 
 static const ALIGN_ASSET(2) char startup_logo_dl19[] = "__OTR__startup_logo/dl19";
 
-static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_87A0[] = "__OTR__startup_logo/startup_logo_seg6_gfx_87A0";
+static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_8548[] = "__OTR__startup_logo/startup_logo_seg6_gfx_8548";
 
 static const ALIGN_ASSET(2) char startup_logo_dl20[] = "__OTR__startup_logo/dl20";
+
+static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_87A0[] = "__OTR__startup_logo/startup_logo_seg6_gfx_87A0";
 
 static const ALIGN_ASSET(2) char startup_reflection_map_gold[] = "__OTR__startup_logo/reflection_map_gold";
 
@@ -220,9 +220,9 @@ static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_9248[] = "__OTR__startup_
 
 static const ALIGN_ASSET(2) char lights[] = "__OTR__startup_logo/lights";
 
-static const ALIGN_ASSET(2) char startup_texture_dl2[] = "__OTR__startup_logo/startup_texture_dl2";
-
 static const ALIGN_ASSET(2) char startup_logo_seg6_gfx_9320[] = "__OTR__startup_logo/startup_logo_seg6_gfx_9320";
+
+static const ALIGN_ASSET(2) char startup_texture_dl2[] = "__OTR__startup_logo/startup_texture_dl2";
 
 static const ALIGN_ASSET(2) char startup_texture_dl3[] = "__OTR__startup_logo/startup_texture_dl3";
 

--- a/include/defines.h
+++ b/include/defines.h
@@ -423,6 +423,8 @@ enum PLACE { FIRST_PLACE, SECOND_PLACE, THIRD_PLACE, FOURTH_PLACE };
 #define SPAWN_FIRST_SHELL 0
 #define SPAWN_SECOND_SHELL 1
 #define SPAWN_THIRD_SHELL 2
+#define ENABLE_SHELLS 3         //When 3 shells are indeed spawned, this state enables collision on all shells
+#define ORBIT_PLAYER 4          //This is when shells are orbiting around the player. This manages if any available shell can be fired
 
 #define GPACK_RGB888(r, g, b) (((r) << 16) | ((g) << 8) | (b))
 #define COLOR_LIGHT GPACK_RGB888(0x1C, 0x00, 0x00)

--- a/properties.h
+++ b/properties.h
@@ -5,10 +5,10 @@
 #define VER_PRODUCTVERSION       0, 1, 0, 0
 #define VER_PRODUCTVERSION_str   "0.1.0\0"
 
-#define VER_COMPANYNAME_STR      "Spaghettikart Team - Harbourmasters\0"
+#define VER_COMPANYNAME_STR      "MegaMech\0"
 #define VER_PRODUCTNAME_STR      "Spaghettikart\0"
 
-#define VER_INTERNALNAME_STR     "Spaghettikart\0"
+#define VER_INTERNALNAME_STR     "Spaghettify\0"
 #define VER_ORIGINALFILENAME_STR "Spaghettify.exe\0"
 
-#define VER_FILEDESCRIPTION_STR  "Spaghettikart -  Alfredo Alfa\0"
+#define VER_FILEDESCRIPTION_STR  "Spaghettikart - Alfredo Alfa\0"

--- a/src/actors/green_shell/update.inc.c
+++ b/src/actors/green_shell/update.inc.c
@@ -59,7 +59,7 @@ void update_actor_green_shell(struct ShellActor* shell) {
                 controller = &gControllers[shell->playerId];
                 if ((controller->buttonDepressed & Z_TRIG) != 0) {
                     controller->buttonDepressed &= ~Z_TRIG;
-                    if (controller->rawStickY < -0x2D) {
+                    if (controller->rawStickY < -0x2D) {        //green shell fired behind
                         var_f2 = 8.0f;
                         if (player->speed > 8.0f) {
                             var_f2 = player->speed * 1.2f;
@@ -71,14 +71,14 @@ void update_actor_green_shell(struct ShellActor* shell) {
                         shell->velocity[0] = somePosVel[0];
                         shell->velocity[1] = somePosVel[1];
                         shell->velocity[2] = somePosVel[2];
-                        shell->state = 2;
+                        shell->state = MOVING_SHELL;
                         func_800C9060(shell->playerId, SOUND_ARG_LOAD(0x19, 0x00, 0x80, 0x04));
                         func_800C90F4(shell->playerId,
                                       (player->characterId * 0x10) + SOUND_ARG_LOAD(0x29, 0x00, 0x80, 0x00));
                         add_green_shell_in_unexpired_actor_list(CM_FindActorIndex(shell));
                         return;
                     } else {
-                        shell->state = 1;
+                        shell->state = RELEASED_SHELL;
                         if (player->unk_0C0 > 0) {
                             shell->rotAngle = 0x78E3;
                         } else {

--- a/src/code_80005FD0.h
+++ b/src/code_80005FD0.h
@@ -94,6 +94,14 @@ enum CpuItemStrategyEnum {
     CPU_STRATEGY_ITEM_BLUE_SPINY_SHELL,
     CPU_STRATEGY_THROW_BLUE_SPINY_SHELL,
     CPU_STRATEGY_HOLD_BLUE_SPINY_SHELL,
+
+    CPU_STRATEGY_ITEM_TRIPLE_GREEN_SHELL,       //triple shell item activated
+    CPU_STRATEGY_ORBIT_TRIPLE_GREEN_SHELL,      //Wait the spawn of 3 shells and orbit around player
+    CPU_STRATEGY_THROW_TRIPLE_GREEN_SHELL,      //Checks if there is any available shell to be fired
+
+    CPU_STRATEGY_ITEM_TRIPLE_RED_SHELL,
+    CPU_STRATEGY_ORBIT_TRIPLE_RED_SHELL,
+    CPU_STRATEGY_THROW_TRIPLE_RED_SHELL,
 };
 
 /* Function Prototypes */

--- a/src/port/ui/PortMenu.cpp
+++ b/src/port/ui/PortMenu.cpp
@@ -383,6 +383,11 @@ void PortMenu::AddEnhancements() {
 
     AddWidget(path, "Harder CPU", WIDGET_CVAR_CHECKBOX).CVar("gHarderCPU");
 
+    AddWidget(path, "CPU use same items as Players", WIDGET_CVAR_CHECKBOX)
+        .CVar("gCPUHumanLikeItems")
+        .Options(
+            CheckboxOptions().Tooltip("CPU will receive the same items as a human player would. Exception is Thunderbolt - most of it probabilities are transferred to Blue Spiny Shells.").DefaultValue(false));
+
     AddWidget(path, "Show Spaghetti version", WIDGET_CVAR_CHECKBOX)
         .CVar("gShowSpaghettiVersion")
         .Options(CheckboxOptions().Tooltip("Show the Spaghetti Kart version on the Mario Kart menu").DefaultValue(true));

--- a/src/update_objects.c
+++ b/src/update_objects.c
@@ -3063,6 +3063,150 @@ ItemProbabilities grandPrixHardCPUProbabilityTable[] = {
       .superMushroom = 10 },
 };
 
+//Almost the same item distribution for cpus, with exception of thunder rates from 2nd to 6th being transfered to blue shells.
+//7th and 8th is just 5% chance each, so overall 10% when ahead and 5% when 7th or bellow
+//Reason is: I believe MK64 thunder is too obnoxious, the strongest item of all, meanwhile blue shells barely cause any harm due to 3A acceleration.
+//If you're lagging behind, spiny actually forces you drive outside of normal racelines so it helps you catch a cheating cpu far ahead.
+//Overall, spiny actually balances the game a lot better and creates mayhem on the pack, meanwhile thunder just dirupts and is very frustrating when spammed
+ItemProbabilities grandPrixCpuHumanLikeProbabilityTable[] = {
+    //1st
+    { .none = 0,
+      .banana = 30,
+      .bananaBunch = 5,
+      .greenShell = 30,
+      .tripleGreenShell = 5,
+      .redShell = 5,
+      .tripleRedShell = 0,
+      .blueSpinyShell = 0,
+      .thunderbolt = 0,
+      .fakeItemBox = 10,
+      .star = 0,
+      .boo = 5,
+      .mushroom = 10,
+      .doubleMushroom = 0,
+      .tripleMushroom = 0,
+      .superMushroom = 0 },
+    //2nd
+    { .none = 0,
+      .banana = 0,
+      .bananaBunch = 5,
+      .greenShell = 5,
+      .tripleGreenShell = 10,
+      .redShell = 15,
+      .tripleRedShell = 20,
+      .blueSpinyShell = 5,
+      .thunderbolt = 0,
+      .fakeItemBox = 5,
+      .star = 5,
+      .boo = 5,
+      .mushroom = 5,
+      .doubleMushroom = 0,
+      .tripleMushroom = 15,
+      .superMushroom = 5 },
+    //3rd
+    { .none = 0,
+      .banana = 0,
+      .bananaBunch = 0,
+      .greenShell = 0,
+      .tripleGreenShell = 10,
+      .redShell = 20,
+      .tripleRedShell = 20,
+      .blueSpinyShell = 5,
+      .thunderbolt = 0,
+      .fakeItemBox = 0,
+      .star = 10,
+      .boo = 0,
+      .mushroom = 5,
+      .doubleMushroom = 0,
+      .tripleMushroom = 20,
+      .superMushroom = 10 },
+    //4th
+    { .none = 0,
+      .banana = 0,
+      .bananaBunch = 0,
+      .greenShell = 0,
+      .tripleGreenShell = 0,
+      .redShell = 15,
+      .tripleRedShell = 20,
+      .blueSpinyShell = 15,
+      .thunderbolt = 0,
+      .fakeItemBox = 0,
+      .star = 15,
+      .boo = 0,
+      .mushroom = 5,
+      .doubleMushroom = 0,
+      .tripleMushroom = 20,
+      .superMushroom = 10 },
+    //5th
+    { .none = 0,
+      .banana = 0,
+      .bananaBunch = 0,
+      .greenShell = 0,
+      .tripleGreenShell = 0,
+      .redShell = 10,
+      .tripleRedShell = 20,
+      .blueSpinyShell = 15,
+      .thunderbolt = 0,
+      .fakeItemBox = 0,
+      .star = 15,
+      .boo = 0,
+      .mushroom = 5,
+      .doubleMushroom = 0,
+      .tripleMushroom = 25,
+      .superMushroom = 10 },
+    //6th
+    { .none = 0,
+      .banana = 0,
+      .bananaBunch = 0,
+      .greenShell = 0,
+      .tripleGreenShell = 0,
+      .redShell = 0,
+      .tripleRedShell = 20,
+      .blueSpinyShell = 25,
+      .thunderbolt = 0,
+      .fakeItemBox = 0,
+      .star = 20,
+      .boo = 0,
+      .mushroom = 0,
+      .doubleMushroom = 0,
+      .tripleMushroom = 25,
+      .superMushroom = 10 },
+    //7th
+    { .none = 0,
+      .banana = 0,
+      .bananaBunch = 0,
+      .greenShell = 0,
+      .tripleGreenShell = 0,
+      .redShell = 0,
+      .tripleRedShell = 20,
+      .blueSpinyShell = 25,
+      .thunderbolt = 5,
+      .fakeItemBox = 0,
+      .star = 30,
+      .boo = 0,
+      .mushroom = 0,
+      .doubleMushroom = 0,
+      .tripleMushroom = 10,
+      .superMushroom = 10 },
+    //8th
+    { .none = 0,
+      .banana = 0,
+      .bananaBunch = 0,
+      .greenShell = 0,
+      .tripleGreenShell = 0,
+      .redShell = 0,
+      .tripleRedShell = 20,
+      .blueSpinyShell = 30,
+      .thunderbolt = 5,
+      .fakeItemBox = 0,
+      .star = 30,
+      .boo = 0,
+      .mushroom = 0,
+      .doubleMushroom = 0,
+      .tripleMushroom = 5,
+      .superMushroom = 10 },
+};
+
 ItemProbabilities versus2PlayerProbabilityTable[] = {
     { .none = 0,
       .banana = 25,
@@ -3276,6 +3420,7 @@ enum RandomItemOption {
     HUMAN_TABLE,
     CPU_TABLE,
     HARD_CPU_TABLE,
+    CPU_HUMAN_LIKE_TABLE,       //CPU item table almost identical of human player, with adjustments only to thunder chances being transferred to spiny shell
 };
 
 /**
@@ -3305,6 +3450,11 @@ u8 gen_random_item(s16 rank, s16 option) {
                     distributionTable = &grandPrixHardCPUProbabilityTable[rank];
                     verify_probability_table("Hard CPU", distributionTable, rank);
                     break;
+                case CPU_HUMAN_LIKE_TABLE:
+                    distributionTable = &grandPrixCpuHumanLikeProbabilityTable[rank];
+                    verify_probability_table("CPU Human Like", distributionTable, rank);
+                    break;
+
             }
             break;
         case VERSUS:
@@ -3351,11 +3501,20 @@ u8 gen_random_item_human(UNUSED s16 arg0, s16 rank) {
 }
 
 u8 cpu_gen_random_item(UNUSED s32 arg0, s16 rank) {
-    return gen_random_item(rank, CPU_TABLE);
+    if (CVarGetInteger("gCPUHumanLikeItems", 0) == true) {
+        return gen_random_item(rank, CPU_HUMAN_LIKE_TABLE);
+    } else {
+        return gen_random_item(rank, CPU_TABLE);
+    }
 }
 
 u8 hard_cpu_gen_random_item(UNUSED s32 arg0, s16 rank) {
-    return gen_random_item(rank, HARD_CPU_TABLE);
+    //Overrides Hard CPU mode item table
+    if (CVarGetInteger("gCPUHumanLikeItems", 0) == true) {
+        return gen_random_item(rank, CPU_HUMAN_LIKE_TABLE);
+    } else {
+        return gen_random_item(rank, HARD_CPU_TABLE);
+    }
 }
 
 s16 func_8007AFB0(s32 objectIndex, s32 playerId) {


### PR DESCRIPTION
Implements triple green/shell CPU strategies. CPUs will spawn then fire all 3 shells. 

Fixed Blue shell not being throw. 

Implemented CPU firing single greenshell backwards if they're ahead of Player 1 or Human Player 2

Implemented new Option: CPU use same items as human players.
It overrides CPU item table both on normal HARD CPU mode.
It is almost exactly a copy of Human Item Table, with exceptions made for Lightning Bolt. All chances of Bolt from 2nd to 6th were added to Blue shell, 7th and 8th place got only 5% chance of thunderbolt, the remaining were added to BlueShell



This is my first ever contribution, and first experience with raw C, I hope  I didn't cause many bugs! But also I am so happy. I've always wanted CPU to fully use items just like us since my childhood, my sincere thanks and appreciation for everyone involved on the decomp and spaghetti project!