### PR TITLE
Fix Widget SameLine

### DIFF
--- a/src/port/ui/Menu.cpp
+++ b/src/port/ui/Menu.cpp
@@ -762,11 +762,11 @@ void Menu::DrawElement() {
                                   ImGuiWindowFlags_NoTitleBar);
             }
             // for (auto& entryName : sidebar->at(sectionIndex).sidebarOrder) {
+            style.ItemSpacing.y = 12;
             for (auto& entry : sidebar->at(sectionIndex).columnWidgets.at(i)) {
                 MenuDrawItem(entry, 90 / sidebar->at(sectionIndex).columnCount, menuThemeIndex);
-                ImGui::Spacing();
-                ImGui::Spacing();
             }
+            style.ItemSpacing.y = 4; // original height
             //}
             if (useColumns) {
                 ImGui::EndChild();


### PR DESCRIPTION
Remove the Spacing() calls after MenuDrawItem and wrap the loop with ItemSpacing.y changes.