### PR TITLE
Fix Vertex Stretching

### DIFF
--- a/src/math_util_2.c
+++ b/src/math_util_2.c
@@ -711,7 +711,6 @@ void func_80042330(s32 x, s32 y, u16 angle, f32 scale) {
 
 void func_80042330_unchanged(s32 x, s32 y, u16 angle, f32 scale) {
     Mat4 matrix;
-    // printf("panel %d %d %d\n", x, (s32)OTRGetDimensionFromLeftEdge(x), (s32)OTRGetDimensionFromLeftEdge(0));
 
     mtxf_translation_x_y_rotate_z_scale_x_y(matrix, x, y, angle, scale);
     // convert_to_fixed_point_matrix(&gGfxPool->mtxHud[gMatrixHudCount], matrix);
@@ -719,6 +718,18 @@ void func_80042330_unchanged(s32 x, s32 y, u16 angle, f32 scale) {
     //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     AddHudMatrix(matrix, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+}
+
+// Mixing hud and object matrix stacks results in vtx stretching. Therefore, render_clouds() now use the object matrix stack.
+void func_80042330_unchanged_mtx(s32 x, s32 y, u16 angle, f32 scale) {
+    Mat4 matrix;
+
+    mtxf_translation_x_y_rotate_z_scale_x_y(matrix, x, y, angle, scale);
+    // convert_to_fixed_point_matrix(&gGfxPool->mtxHud[gMatrixHudCount], matrix);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxHud[gMatrixHudCount++]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+
+    AddObjectMatrix(matrix, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 }
 
 // Allows a different way of lining up the portraits at the end of race sequence

--- a/src/math_util_2.h
+++ b/src/math_util_2.h
@@ -72,6 +72,7 @@ void func_80041D34(void);
 void set_matrix_hud_screen(void);
 void func_80042330(s32, s32, u16, f32);
 void func_80042330_unchanged(s32 x, s32 y, u16 angle, f32 scale);
+void func_80042330_unchanged_mtx(s32 x, s32 y, u16 angle, f32 scale);
 void func_80042330_portrait(s32, s32, u16, f32, s16);
 void func_80042330_wide(s32, s32, u16, f32);
 void mtxf_set_matrix_transformation(Mat4, Vec3f, Vec3su, f32);

--- a/src/port/interpolation/FrameInterpolation.h
+++ b/src/port/interpolation/FrameInterpolation.h
@@ -22,6 +22,7 @@ extern "C" {
 #define TAG_SMOKE_DUST(x) ((u32) 0x20000000 | (u32) (x))
 #define TAG_LETTER(x) ((u32)0x30000000 | (u32) (uintptr_t) (x))
 #define TAG_OBJECT(x) ((u32)0x40000000 | (u32) (uintptr_t) (x))
+#define TAG_CLOUDS(x) ((u32)0x50000000 | (u32) (uintptr_t) (x))
 
 void FrameInterpolation_ShouldInterpolateFrame(bool shouldInterpolate);
 

--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -3484,7 +3484,7 @@ struct ObjectInterpData {
 
 struct ObjectInterpData prevObject[OBJECT_LIST_SIZE] = { 0 };
 
-void func_800518F8(s32 objectIndex, s16 x, s16 y) {
+void render_clouds(s32 objectIndex, s16 x, s16 y) {
 
     // Search all recorded objects for the one we're drawing
     for (size_t i = 0; i < OBJECT_LIST_SIZE; i++) {
@@ -3503,14 +3503,15 @@ void func_800518F8(s32 objectIndex, s16 x, s16 y) {
     if (gObjectList[objectIndex].status & 0x10) {
 
         // @port: Tag the transform.
-        FrameInterpolation_RecordOpenChild("func_800518F8", (uintptr_t) &gObjectList[objectIndex]);
+        FrameInterpolation_RecordOpenChild("cloud_render", TAG_CLOUDS(objectIndex));
+
 
         if (D_8018D228 != gObjectList[objectIndex].unk_0D5) {
             D_8018D228 = gObjectList[objectIndex].unk_0D5;
             func_80044DA0(gObjectList[objectIndex].activeTexture, gObjectList[objectIndex].textureWidth,
                           gObjectList[objectIndex].textureHeight);
         }
-        func_80042330_unchanged(x, y, 0, gObjectList[objectIndex].sizeScaling);
+        func_80042330_unchanged_mtx(x, y, 0, gObjectList[objectIndex].sizeScaling);
         gSPVertex(gDisplayListHead++, gObjectList[objectIndex].vertex, 4, 0);
         gSPDisplayList(gDisplayListHead++, common_rectangle_display);
 
@@ -3532,7 +3533,7 @@ void func_800519D4(s32 objectIndex, s16 arg1, s16 arg2) {
                           gObjectList[objectIndex].textureHeight);
         }
         func_8004B138(0x000000FF, 0x000000FF, 0x000000FF, gObjectList[objectIndex].primAlpha);
-        func_80042330_unchanged(arg1, arg2, 0U, gObjectList[objectIndex].sizeScaling);
+        func_80042330_unchanged_mtx(arg1, arg2, 0U, gObjectList[objectIndex].sizeScaling);
         gSPVertex(gDisplayListHead++, gObjectList[objectIndex].vertex, 4, 0);
         gSPDisplayList(gDisplayListHead++, common_rectangle_display);
     }
@@ -3562,13 +3563,7 @@ void func_80051ABC(s16 arg0, s32 arg1) {
             objectIndex = D_8018CC80[arg1 + var_s0];
             object = &gObjectList[objectIndex];
 
-            // @port: Tag the transform.
-            FrameInterpolation_RecordOpenChild("func_80051ABC", TAG_OBJECT(object));
-
-            func_800518F8(objectIndex, object->unk_09C, arg0 - object->unk_09E);
-
-            // @port Pop the transform id.
-            FrameInterpolation_RecordCloseChild();
+            render_clouds(objectIndex, object->unk_09C, arg0 - object->unk_09E);
         }
     }
 }
@@ -3610,7 +3605,7 @@ void func_80051C60(s16 arg0, s32 arg1) {
         for (var_s0 = 0; var_s0 < D_8018D1F0; var_s0++) {
             objectIndex = D_8018CC80[arg1 + var_s0];
             object = &gObjectList[objectIndex];
-            func_800518F8(objectIndex, object->unk_09C, (var_s5 - object->unk_09E) / 2);
+            render_clouds(objectIndex, object->unk_09C, (var_s5 - object->unk_09E) / 2);
         }
     }
 }

--- a/src/render_objects.h
+++ b/src/render_objects.h
@@ -318,7 +318,7 @@ void func_80050E34(s32, s32);
 void func_800514BC(void);
 void render_object_leaf_particle(s32);
 void render_object_snowflakes_particles(void);
-void func_800518F8(s32, s16, s16);
+void render_clouds(s32, s16, s16);
 void func_800519D4(s32, s16, s16);
 void func_80051ABC(s16, s32);
 void func_80051C60(s16, s32);


### PR DESCRIPTION
Turns out mixing matrix stacks in the interpolation engine results in vtx stretching issues.

Clarified the interpolation tagging in-case that helps as well.

Improves or resolves https://github.com/HarbourMasters/SpaghettiKart/issues/296