### PR TITLE
Combine Matrix Stacks To Fix Vtx Stretching

### DIFF
--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -544,10 +544,13 @@ void render_object(u32 arg0) {
 
 void render_object_p1(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+
+    PushPerspectiveMatrix(PLAYER_ONE, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    PushLookAtMatrix(PLAYER_ONE, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
+    //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
 
     // if (gGamestate == ENDING) {
     //     //func_80055F48(PLAYER_ONE);
@@ -560,33 +563,40 @@ void render_object_p1(void) {
 }
 
 void render_object_p2(void) {
-
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[1]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[1]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+
+    PushPerspectiveMatrix(PLAYER_TWO, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    PushLookAtMatrix(PLAYER_TWO, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[1]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[1]),
+    //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     // render_bomb_karts_wrap(PLAYER_TWO);
     render_object_for_player(PLAYER_TWO);
 }
 
 void render_object_p3(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[2]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[2]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+
+    PushPerspectiveMatrix(PLAYER_THREE, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    PushLookAtMatrix(PLAYER_THREE, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[2]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[2]),
+    //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     // render_bomb_karts_wrap(PLAYER_THREE);
     render_object_for_player(PLAYER_THREE);
 }
 
 void render_object_p4(void) {
-
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[3]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[3]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+
+    PushPerspectiveMatrix(PLAYER_FOUR, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    PushLookAtMatrix(PLAYER_FOUR, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[3]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[3]),
+    //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     // render_bomb_karts_wrap(PLAYER_FOUR);
     if ((!gDemoMode) && (gPlayerCountSelection1 == 4)) {
         // render_lakitu(PLAYER_FOUR);
@@ -639,10 +649,12 @@ void render_player_snow_effect(u32 arg0) {
 
 void render_player_snow_effect_one(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    PushPerspectiveMatrix(PLAYER_ONE, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    PushLookAtMatrix(PLAYER_ONE, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
+    //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     if (gGamestate != ENDING) {
         render_snowing_effect(PLAYER_ONE);
     }
@@ -650,28 +662,34 @@ void render_player_snow_effect_one(void) {
 
 void render_player_snow_effect_two(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[1]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[1]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    PushPerspectiveMatrix(PLAYER_TWO, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    PushLookAtMatrix(PLAYER_TWO, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[1]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[1]),
+    //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     render_snowing_effect(PLAYER_TWO);
 }
 
 void render_player_snow_effect_three(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[2]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[2]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    PushPerspectiveMatrix(PLAYER_THREE, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    PushLookAtMatrix(PLAYER_THREE, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[2]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[2]),
+    //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     render_snowing_effect(PLAYER_THREE);
 }
 
 void render_player_snow_effect_four(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[3]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[3]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    PushPerspectiveMatrix(PLAYER_FOUR, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    PushLookAtMatrix(PLAYER_FOUR, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[3]),
+    //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[3]),
+    //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     render_snowing_effect(PLAYER_FOUR);
 }
 

--- a/src/ending/code_80280000.c
+++ b/src/ending/code_80280000.c
@@ -48,6 +48,8 @@ void func_80280038(void) {
     ClearMatrixPools();
     Editor_ClearMatrix();
 
+    ReserveMatrices();
+
     gMatrixObjectCount = 0;
     gMatrixEffectCount = 0;
     gMatrixHudCount = 0;

--- a/src/ending/podium_ceremony_actors.c
+++ b/src/ending/podium_ceremony_actors.c
@@ -466,6 +466,9 @@ void podium_ceremony_loop(void) {
     Editor_ClearMatrix();
     gMatrixObjectCount = 0;
     D_802874FC = 0;
+
+    ReserveMatrices();
+
     update_camera_podium_ceremony();
     func_80028F70();
     func_80022744();

--- a/src/engine/Matrix.cpp
+++ b/src/engine/Matrix.cpp
@@ -26,10 +26,38 @@ Mtx* GetMatrix(std::vector<Mtx>& stack) {
     return &stack.back();
 }
 
+static Mtx* PerspectiveMatrix[4];
+static Mtx* LookAtMatrix[4];
+static Mtx* KartMatrix[NUM_PLAYERS * 4]; // 8 players * 4 screens
+static Mtx* ShadowMatrix[NUM_PLAYERS * 4]; // 8 players * 4 screens
+
+
+// Reserves perspective, lookAt, and kart matrices at the start of a frame
+void ReserveMatrices(void) {
+    gWorldInstance.Mtx.Objects.reserve(500);
+
+    for (size_t i = 0; i < ARRAY_COUNT(PerspectiveMatrix); i++) {
+        PerspectiveMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
+    }
+
+    for (size_t i = 0; i < ARRAY_COUNT(LookAtMatrix); i++) {
+        LookAtMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
+    }
+
+    for (size_t i = 0; i < ARRAY_COUNT(KartMatrix); i++) {
+        KartMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
+    }
+
+    for (size_t i = 0; i < ARRAY_COUNT(ShadowMatrix); i++) {
+        ShadowMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
+    }
+}
+
 /**
- * Use GetMatrix() first
+ * Push a fixed point matrix to the stack
+ * Use GetMatrix() before calling this
  */
-void AddMatrixFixed(std::vector<Mtx>& stack, s32 flags) {
+inline void AddMatrixFixed(std::vector<Mtx>& stack, s32 flags) {
     // Load the matrix
     gSPMatrix(gDisplayListHead++, &stack.back(), flags);
 }
@@ -145,39 +173,39 @@ void AddLocalRotation(Mat4 mat, IRotator rot) {
 extern "C" {
 
     void AddHudMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(gWorldInstance.Mtx.Hud, mtx, flags);
+        AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
     void AddPerspMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(gWorldInstance.Mtx.Persp, mtx, flags);
+        AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
-    void AddLookAtMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(gWorldInstance.Mtx.LookAt, mtx, flags);
-    }
+    // void AddLookAtMatrix(Mat4 mtx, s32 flags) {
+    //     AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
+    // }
 
     void AddObjectMatrix(Mat4 mtx, s32 flags) {
         AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
     void AddShadowMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(gWorldInstance.Mtx.Shadows, mtx, flags);
+        AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
     void AddKartMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(gWorldInstance.Mtx.Karts, mtx, flags);
+        AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
     void AddEffectMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(gWorldInstance.Mtx.Effects, mtx, flags);
+        AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
     void AddEffectMatrixFixed(s32 flags) {
-        AddMatrixFixed(gWorldInstance.Mtx.Effects, flags);
+        AddMatrixFixed(gWorldInstance.Mtx.Objects, flags);
     }
 
     void AddEffectMatrixOrtho(void) {
-        auto& stack = gWorldInstance.Mtx.Effects;
+        auto& stack = gWorldInstance.Mtx.Objects;
         stack.emplace_back();
 
         guOrtho(&stack.back(), 0.0f, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1, 0.0f, -100.0f, 100.0f, 1.0f);
@@ -185,8 +213,54 @@ extern "C" {
         gSPMatrix(gDisplayListHead++, &stack.back(), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
     }
 
+    Mtx* GetPerspectiveMatrix(s32 cameraId) {
+        if (cameraId >= 0 && cameraId < ARRAY_COUNT(PerspectiveMatrix)) {
+            return PerspectiveMatrix[cameraId];
+        } else {
+            return NULL;
+        }
+    }
+
+    Mtx* GetLookAtMatrix(s32 cameraId) {
+        if (cameraId >= 0 && cameraId < ARRAY_COUNT(LookAtMatrix)) {
+            return LookAtMatrix[cameraId];
+        } else {
+            return NULL;
+        }
+    }
+
+    void PushPerspectiveMatrix(s32 cameraId, s32 flags) {
+        if (cameraId >= 0 && cameraId < ARRAY_COUNT(PerspectiveMatrix)) {
+            gSPMatrix(gDisplayListHead++, PerspectiveMatrix[cameraId], flags);
+        }
+    }
+
+    void PushLookAtMatrix(s32 cameraId, s32 flags) {
+        if (cameraId >= 0 && cameraId < ARRAY_COUNT(LookAtMatrix)) {
+            gSPMatrix(gDisplayListHead++, LookAtMatrix[cameraId], flags);
+        }
+    }
+
+    // Id is playerId + (screenId * 8)
+    void PushKartMatrix(Mat4 mtx, s32 id, s32 flags) {
+        if (id >= 0 && id < ARRAY_COUNT(KartMatrix)) {
+            FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, KartMatrix[id]);
+            guMtxF2L(mtx, KartMatrix[id]);
+            gSPMatrix(gDisplayListHead++, KartMatrix[id], flags);
+        }
+    }
+
+    // Id is playerId + (screenId * 8)
+    void PushShadowMatrix(Mat4 mtx, s32 id, s32 flags) {
+        if (id >= 0 && id < ARRAY_COUNT(ShadowMatrix)) {
+            FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, ShadowMatrix[id]);
+            guMtxF2L(mtx, ShadowMatrix[id]);
+            gSPMatrix(gDisplayListHead++, ShadowMatrix[id], flags);
+        }
+    }
+
     Mtx* GetEffectMatrix(void) {
-        return GetMatrix(gWorldInstance.Mtx.Effects);
+        return GetMatrix(gWorldInstance.Mtx.Objects);
     }
 
 

--- a/src/engine/Matrix.cpp
+++ b/src/engine/Matrix.cpp
@@ -33,6 +33,7 @@ static Mtx* ShadowMatrix[NUM_PLAYERS * 4]; // 8 players * 4 screens
 
 
 // Reserves perspective, lookAt, and kart matrices at the start of a frame
+// This must be ran at the start of every frame for race_logic_loop(), credits_loop(), and podium_ceremony_loop()
 void ReserveMatrices(void) {
     gWorldInstance.Mtx.Objects.reserve(500); // Required to prevent corrupt heap memory crashes.
 

--- a/src/engine/Matrix.cpp
+++ b/src/engine/Matrix.cpp
@@ -34,7 +34,7 @@ static Mtx* ShadowMatrix[NUM_PLAYERS * 4]; // 8 players * 4 screens
 
 // Reserves perspective, lookAt, and kart matrices at the start of a frame
 void ReserveMatrices(void) {
-    gWorldInstance.Mtx.Objects.reserve(500);
+    gWorldInstance.Mtx.Objects.reserve(500); // Required to prevent corrupt heap memory crashes.
 
     for (size_t i = 0; i < ARRAY_COUNT(PerspectiveMatrix); i++) {
         PerspectiveMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();

--- a/src/engine/Matrix.cpp
+++ b/src/engine/Matrix.cpp
@@ -9,7 +9,7 @@ extern "C" {
 #include "math_util_2.h"
 }
 
-void AddMatrix(std::vector<Mtx>& stack, Mat4 mtx, s32 flags) {
+void AddMatrix(std::deque<Mtx>& stack, Mat4 mtx, s32 flags) {
     // Push a new matrix to the stack
     stack.emplace_back();
 
@@ -21,7 +21,7 @@ void AddMatrix(std::vector<Mtx>& stack, Mat4 mtx, s32 flags) {
     gSPMatrix(gDisplayListHead++, &stack.back(), flags);
 }
 
-Mtx* GetMatrix(std::vector<Mtx>& stack) {
+Mtx* GetMatrix(std::deque<Mtx>& stack) {
     stack.emplace_back();
     return &stack.back();
 }
@@ -35,30 +35,30 @@ static Mtx* ShadowMatrix[NUM_PLAYERS * 4]; // 8 players * 4 screens
 // Reserves perspective, lookAt, and kart matrices at the start of a frame
 // This must be ran at the start of every frame for race_logic_loop(), credits_loop(), and podium_ceremony_loop()
 void ReserveMatrices(void) {
-    gWorldInstance.Mtx.Objects.reserve(500); // Required to prevent corrupt heap memory crashes.
+    // gWorldInstance.Mtx.Objects.reserve(500); // Required to prevent corrupt heap memory crashes.
 
-    for (size_t i = 0; i < ARRAY_COUNT(PerspectiveMatrix); i++) {
-        PerspectiveMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
-    }
+    // for (size_t i = 0; i < ARRAY_COUNT(PerspectiveMatrix); i++) {
+    //     PerspectiveMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
+    // }
 
-    for (size_t i = 0; i < ARRAY_COUNT(LookAtMatrix); i++) {
-        LookAtMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
-    }
+    // for (size_t i = 0; i < ARRAY_COUNT(LookAtMatrix); i++) {
+    //     LookAtMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
+    // }
 
-    for (size_t i = 0; i < ARRAY_COUNT(KartMatrix); i++) {
-        KartMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
-    }
+    // for (size_t i = 0; i < ARRAY_COUNT(KartMatrix); i++) {
+    //     KartMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
+    // }
 
-    for (size_t i = 0; i < ARRAY_COUNT(ShadowMatrix); i++) {
-        ShadowMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
-    }
+    // for (size_t i = 0; i < ARRAY_COUNT(ShadowMatrix); i++) {
+    //     ShadowMatrix[i] = &gWorldInstance.Mtx.Objects.emplace_back();
+    // }
 }
 
 /**
  * Push a fixed point matrix to the stack
  * Use GetMatrix() before calling this
  */
-inline void AddMatrixFixed(std::vector<Mtx>& stack, s32 flags) {
+inline void AddMatrixFixed(std::deque<Mtx>& stack, s32 flags) {
     // Load the matrix
     gSPMatrix(gDisplayListHead++, &stack.back(), flags);
 }
@@ -87,14 +87,14 @@ void SetTextMatrix(Mat4 mf, f32 x, f32 y, f32 arg3, f32 arg4) {
 // AddMatrix but with custom gfx ptr arg and flags are predefined
 Gfx* AddTextMatrix(Gfx* displayListHead, Mat4 mtx) {
     // Push a new matrix to the stack
-    gWorldInstance.Mtx.Effects.emplace_back();
+    gWorldInstance.Mtx.Objects.emplace_back();
 
     // Convert to a fixed-point matrix
-    FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &gWorldInstance.Mtx.Effects.back());
-    guMtxF2L(mtx, &gWorldInstance.Mtx.Effects.back());
+    FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &gWorldInstance.Mtx.Objects.back());
+    guMtxF2L(mtx, &gWorldInstance.Mtx.Objects.back());
 
     // Load the matrix
-    gSPMatrix(displayListHead++, &gWorldInstance.Mtx.Effects.back(), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(displayListHead++, &gWorldInstance.Mtx.Objects.back(), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     return displayListHead;
 }
@@ -216,7 +216,7 @@ extern "C" {
 
     Mtx* GetPerspectiveMatrix(s32 cameraId) {
         if (cameraId >= 0 && cameraId < ARRAY_COUNT(PerspectiveMatrix)) {
-            return PerspectiveMatrix[cameraId];
+            return &gWorldInstance.Mtx.Persp[cameraId];
         } else {
             return NULL;
         }
@@ -224,7 +224,7 @@ extern "C" {
 
     Mtx* GetLookAtMatrix(s32 cameraId) {
         if (cameraId >= 0 && cameraId < ARRAY_COUNT(LookAtMatrix)) {
-            return LookAtMatrix[cameraId];
+            return &gWorldInstance.Mtx.LookAt[cameraId];
         } else {
             return NULL;
         }
@@ -232,31 +232,31 @@ extern "C" {
 
     void PushPerspectiveMatrix(s32 cameraId, s32 flags) {
         if (cameraId >= 0 && cameraId < ARRAY_COUNT(PerspectiveMatrix)) {
-            gSPMatrix(gDisplayListHead++, PerspectiveMatrix[cameraId], flags);
+            gSPMatrix(gDisplayListHead++, &gWorldInstance.Mtx.Persp[cameraId], flags);
         }
     }
 
     void PushLookAtMatrix(s32 cameraId, s32 flags) {
         if (cameraId >= 0 && cameraId < ARRAY_COUNT(LookAtMatrix)) {
-            gSPMatrix(gDisplayListHead++, LookAtMatrix[cameraId], flags);
+            gSPMatrix(gDisplayListHead++, &gWorldInstance.Mtx.LookAt[cameraId], flags);
         }
     }
 
     // Id is playerId + (screenId * 8)
     void PushKartMatrix(Mat4 mtx, s32 id, s32 flags) {
         if (id >= 0 && id < ARRAY_COUNT(KartMatrix)) {
-            FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, KartMatrix[id]);
-            guMtxF2L(mtx, KartMatrix[id]);
-            gSPMatrix(gDisplayListHead++, KartMatrix[id], flags);
+            FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &gWorldInstance.Mtx.Karts[id]);
+            guMtxF2L(mtx, &gWorldInstance.Mtx.Karts[id]);
+            gSPMatrix(gDisplayListHead++, &gWorldInstance.Mtx.Karts[id], flags);
         }
     }
 
     // Id is playerId + (screenId * 8)
     void PushShadowMatrix(Mat4 mtx, s32 id, s32 flags) {
         if (id >= 0 && id < ARRAY_COUNT(ShadowMatrix)) {
-            FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, ShadowMatrix[id]);
-            guMtxF2L(mtx, ShadowMatrix[id]);
-            gSPMatrix(gDisplayListHead++, ShadowMatrix[id], flags);
+            FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &gWorldInstance.Mtx.Shadows[id]);
+            guMtxF2L(mtx, &gWorldInstance.Mtx.Shadows[id]);
+            gSPMatrix(gDisplayListHead++, &gWorldInstance.Mtx.Shadows[id], flags);
         }
     }
 
@@ -272,8 +272,8 @@ extern "C" {
     void ClearMatrixPools(void) {
         gWorldInstance.Mtx.Hud.clear();
         gWorldInstance.Mtx.Objects.clear();
-        gWorldInstance.Mtx.Shadows.clear();
-        gWorldInstance.Mtx.Karts.clear();
+       // gWorldInstance.Mtx.Shadows.clear();
+       // gWorldInstance.Mtx.Karts.clear();
         gWorldInstance.Mtx.Effects.clear();
     }
 

--- a/src/engine/Matrix.h
+++ b/src/engine/Matrix.h
@@ -11,6 +11,7 @@ extern "C" {
 void ApplyMatrixTransformations(Mat4 mtx, FVector pos, IRotator rot, FVector scale);
 void AddLocalRotation(Mat4 mat, IRotator rot);
 #endif
+void ReserveMatrices(void);
 void ClearMatrixPools(void);
 void AddHudMatrix(Mat4 mtx, s32 flags);
 void AddObjectMatrix(Mat4 mtx, s32 flags);
@@ -19,6 +20,14 @@ void AddEffectMatrixOrtho(void);
 void AddEffectMatrixFixed(s32 flags);
 void SetTextMatrix(Mat4 mf, f32 arg1, f32 arg2, f32 arg3, f32 arg4);
 Gfx* AddTextMatrix(Gfx* displayListHead, Mat4 mtx);
+
+Mtx* GetPerspectiveMatrix(s32 cameraId);
+Mtx* GetLookAtMatrix(s32 cameraId);
+void PushPerspectiveMatrix(s32 cameraId, s32 flags);
+void PushLookAtMatrix(s32 cameraId, s32 flags);
+void PushKartMatrix(Mat4 mtx, s32 id, s32 flags);
+void PushShadowMatrix(Mat4 mtx, s32 id, s32 flags);
+
 Mtx* GetEffectMatrix(void);
 void ClearHudMatrixPool(void);
 void ClearEffectsMatrixPool(void);

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -41,13 +41,13 @@ class GameObject; // <-- Editor
 
 class World {
     typedef struct {
-        std::vector<Mtx> Hud;
-        std::vector<Mtx> Objects;
-        std::vector<Mtx> Shadows;
-        std::vector<Mtx> Karts;
-        std::vector<Mtx> Effects;
-        std::vector<Mtx> Persp;
-        std::vector<Mtx> LookAt;
+        std::deque<Mtx> Hud;
+        std::deque<Mtx> Objects;
+        std::array<Mtx,32> Shadows;
+        std::array<Mtx,32> Karts;
+        std::deque<Mtx> Effects;
+        std::array<Mtx,4> Persp;
+        std::array<Mtx,4> LookAt;
     } Matrix;
 
 public:

--- a/src/main.c
+++ b/src/main.c
@@ -808,6 +808,8 @@ void race_logic_loop(void) {
     gMatrixObjectCount = 0;
     gMatrixEffectCount = 0;
 
+    ReserveMatrices();
+
     if (gIsGamePaused != 0) {
         func_80290B14();
     }

--- a/src/port/interpolation/FrameInterpolation.h
+++ b/src/port/interpolation/FrameInterpolation.h
@@ -22,6 +22,10 @@ extern "C" {
 #define TAG_SMOKE_DUST(x) ((u32) 0x20000000 | (u32) (x))
 #define TAG_LETTER(x) ((u32)0x30000000 | (u32) (uintptr_t) (x))
 #define TAG_OBJECT(x) ((u32)0x40000000 | (u32) (uintptr_t) (x))
+#define TAG_CLOUDS(x) ((u32)0x50000000 | (u32) (uintptr_t) (x))
+//                          Mask the bits so that the 7 can't get overridden
+#define TAG_TRACK(x) ((u32)0x70000000 | ((u32)(x) & 0x0FFFFFFF))
+
 
 void FrameInterpolation_ShouldInterpolateFrame(bool shouldInterpolate);
 

--- a/src/racing/render_courses.c
+++ b/src/racing/render_courses.c
@@ -215,30 +215,43 @@ void func_8029122C(struct UnkStruct_800DC5EC* arg0, s32 playerId) {
     pathCounter = (u16) arg0->pathCounter;
     cameraRot = (u16) arg0->camera->rot[1];
     playerDirection = arg0->playerDirection;
+
+    // This pushes the camera matrices to the top of the stack.
+    // It does not appear to really do anything.
+    // Perhaps they thought it was necessary to set the camera back to projection mode since rainbow road uses model mode.
+    // But that issue should be cleared up in render_screens() already.
     switch (playerId) {
         case PLAYER_ONE:
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_ONE]),
-                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_ONE]),
-                      G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+            PushPerspectiveMatrix(PLAYER_ONE, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+            PushLookAtMatrix(PLAYER_ONE, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+            // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_ONE]),
+            //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+            // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_ONE]),
+            //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             break;
         case PLAYER_TWO:
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_TWO]),
-                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_TWO]),
-                      G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+            PushPerspectiveMatrix(PLAYER_TWO, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+            PushLookAtMatrix(PLAYER_TWO, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+            // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_TWO]),
+            //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+            // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_TWO]),
+            //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             break;
         case PLAYER_THREE:
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_THREE]),
-                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_THREE]),
-                      G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+            PushPerspectiveMatrix(PLAYER_THREE, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+            PushLookAtMatrix(PLAYER_THREE, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+            // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_THREE]),
+            //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+            // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_THREE]),
+            //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             break;
         case PLAYER_FOUR:
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_FOUR]),
-                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_FOUR]),
-                      G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+            PushPerspectiveMatrix(PLAYER_FOUR, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+            PushLookAtMatrix(PLAYER_FOUR, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+            // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_FOUR]),
+            //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+            // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_FOUR]),
+            //           G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             break;
     }
 

--- a/src/racing/skybox_and_splitscreen.c
+++ b/src/racing/skybox_and_splitscreen.c
@@ -24,6 +24,7 @@
 #include "math_util.h"
 #include "src/enhancements/freecam/freecam.h"
 #include "port/interpolation/FrameInterpolation.h"
+#include "engine/Matrix.h"
 
 Vp D_802B8880[] = {
     { { { 640, 480, 511, 0 }, { 640, 480, 511, 0 } } },
@@ -758,8 +759,14 @@ void func_802A5760(void) {
 
 // Setup the cameras perspective and lookAt (movement/rotation)
 void setup_camera(Camera* camera, s32 playerId, s32 cameraId, struct UnkStruct_800DC5EC* screen) {
-    Mat4 matrix;
+    Mat4 perspMtxF;
+    Mtx* perspMtx = GetPerspectiveMatrix(cameraId);
     u16 perspNorm;
+
+    if (NULL == perspMtx) {
+        printf("[setup_camera] Received NULL perspective Mtx\n");
+        return;
+    }
 
     // This allows freecam to create a new separate camera
     // if (CVarGetInteger("gFreecam", 0) == true) {
@@ -767,20 +774,35 @@ void setup_camera(Camera* camera, s32 playerId, s32 cameraId, struct UnkStruct_8
     //     return;
     // }
 
-    // Setup perspective (camera movement)
+    // Tag the camera for the interpolation engine
     FrameInterpolation_RecordOpenChild("camera",
-                                       (FrameInterpolation_GetCameraEpoch() | (((playerId | cameraId) << 8))));
-    guPerspective(&gGfxPool->mtxPersp[cameraId], &perspNorm, gCameraZoom[cameraId], gScreenAspect,
+                                       (FrameInterpolation_GetCameraEpoch() | (playerId | (cameraId << 8))));
+
+    // Calculate camera perspective (camera movement/location)
+    guPerspective(perspMtx, &perspNorm, gCameraZoom[cameraId], gScreenAspect,
                   CM_GetProps()->NearPersp, CM_GetProps()->FarPersp, 1.0f);
     gSPPerspNormalize(gDisplayListHead++, perspNorm);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[cameraId]),
-              G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
 
-    // Setup lookAt (camera rotation)
-    guLookAt(&gGfxPool->mtxLookAt[cameraId], camera->pos[0], camera->pos[1], camera->pos[2], camera->lookAt[0],
+    // Push the perspective matrix to the matrix stack
+    guMtxL2F(perspMtxF, perspMtx);
+    PushPerspectiveMatrix(cameraId, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+
+    Mat4 lookAtMtxF;
+    Mtx* lookAtMtx = GetLookAtMatrix(cameraId);
+    
+    if (NULL == lookAtMtx) {
+        printf("[setup_camera] Received NULL lookAt Mtx\n");
+        return;
+    }
+
+    // Calculate camera lookAt (camera rotation)
+    guLookAt(lookAtMtx, camera->pos[0], camera->pos[1], camera->pos[2], camera->lookAt[0],
              camera->lookAt[1], camera->lookAt[2], camera->up[0], camera->up[1], camera->up[2]);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[cameraId]),
-              G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+
+    // Push the lookAt matrix to the matrix stack
+    guMtxL2F(lookAtMtxF, lookAtMtx);
+    PushLookAtMatrix(cameraId, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
+
     FrameInterpolation_RecordCloseChild();
 }
 
@@ -856,7 +878,7 @@ void render_screens(s32 mode, s32 cameraId, s32 playerId) {
     //} else {
         camera = &cameras[cameraId];
     //}
-    
+
     if (screenMode == SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL) {
         gSPSetGeometryMode(gDisplayListHead++, G_SHADE | G_CULL_BACK | G_LIGHTING | G_SHADING_SMOOTH);
     }
@@ -870,13 +892,17 @@ void render_screens(s32 mode, s32 cameraId, s32 playerId) {
     setup_camera(camera, playerId, cameraId, screen);
 
     // Create a matrix for the track and game objects
-    FrameInterpolation_RecordOpenChild("track", (playerId | cameraId) << 8);
+    FrameInterpolation_RecordOpenChild("track", TAG_TRACK((cameraId | playerId)));
     Mat4 trackMatrix;
     mtxf_identity(trackMatrix);
     render_set_position(trackMatrix, 0);
 
-    // Draw course and game objects
+    // Draw track geography
     render_course(screen);
+    FrameInterpolation_RecordCloseChild();
+
+
+    // Draw dynamic game objects
     render_course_actors(screen);
     CM_DrawStaticMeshActors();
     render_object(mode);
@@ -912,13 +938,13 @@ void render_screens(s32 mode, s32 cameraId, s32 playerId) {
             break;
     };
 
-    render_item_boxes(screen);
-    render_player_snow_effect(mode);
-    func_80058BF4();
+   render_item_boxes(screen);
+   render_player_snow_effect(mode);
+    func_80058BF4(); // Setup texture modes
     if (D_800DC5B8 != 0) {
-        func_80058C20(mode);
+        func_80058C20(mode); // Setup hud matrix
     }
-    func_80093A5C(mode);
+    func_80093A5C(mode); // Perhaps pause render?
     if (D_800DC5B8 != 0) {
         render_hud(mode);
     }
@@ -927,7 +953,6 @@ void render_screens(s32 mode, s32 cameraId, s32 playerId) {
     if (mode != RENDER_SCREEN_MODE_1P_PLAYER_ONE) {
         gNumScreens += 1;
     }
-    FrameInterpolation_RecordCloseChild();
 }
 
 void func_802A74BC(void) {

--- a/src/racing/skybox_and_splitscreen.c
+++ b/src/racing/skybox_and_splitscreen.c
@@ -921,9 +921,9 @@ void render_screens(s32 mode, s32 cameraId, s32 playerId) {
             render_players_on_screen_four();
             break;
     }
-    func_8029122C(screen, playerId);
+    func_8029122C(screen, playerId); // Track water related
 
-    switch (playerId) {
+    switch (playerId) { // Render player particles or some effect
         case 0:
             func_80021B0C();
             break;
@@ -938,8 +938,8 @@ void render_screens(s32 mode, s32 cameraId, s32 playerId) {
             break;
     };
 
-   render_item_boxes(screen);
-   render_player_snow_effect(mode);
+    render_item_boxes(screen);
+    render_player_snow_effect(mode);
     func_80058BF4(); // Setup texture modes
     if (D_800DC5B8 != 0) {
         func_80058C20(mode); // Setup hud matrix

--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -3484,7 +3484,7 @@ struct ObjectInterpData {
 
 struct ObjectInterpData prevObject[OBJECT_LIST_SIZE] = { 0 };
 
-void func_800518F8(s32 objectIndex, s16 x, s16 y) {
+void render_clouds(s32 objectIndex, s16 x, s16 y) {
 
     // Search all recorded objects for the one we're drawing
     for (size_t i = 0; i < OBJECT_LIST_SIZE; i++) {
@@ -3503,7 +3503,7 @@ void func_800518F8(s32 objectIndex, s16 x, s16 y) {
     if (gObjectList[objectIndex].status & 0x10) {
 
         // @port: Tag the transform.
-        FrameInterpolation_RecordOpenChild("func_800518F8", (uintptr_t) &gObjectList[objectIndex]);
+        FrameInterpolation_RecordOpenChild("cloud_render", TAG_CLOUDS(objectIndex));
 
         if (D_8018D228 != gObjectList[objectIndex].unk_0D5) {
             D_8018D228 = gObjectList[objectIndex].unk_0D5;
@@ -3562,13 +3562,7 @@ void func_80051ABC(s16 arg0, s32 arg1) {
             objectIndex = D_8018CC80[arg1 + var_s0];
             object = &gObjectList[objectIndex];
 
-            // @port: Tag the transform.
-            FrameInterpolation_RecordOpenChild("func_80051ABC", TAG_OBJECT(object));
-
-            func_800518F8(objectIndex, object->unk_09C, arg0 - object->unk_09E);
-
-            // @port Pop the transform id.
-            FrameInterpolation_RecordCloseChild();
+            render_clouds(objectIndex, object->unk_09C, arg0 - object->unk_09E);
         }
     }
 }
@@ -3610,13 +3604,13 @@ void func_80051C60(s16 arg0, s32 arg1) {
         for (var_s0 = 0; var_s0 < D_8018D1F0; var_s0++) {
             objectIndex = D_8018CC80[arg1 + var_s0];
             object = &gObjectList[objectIndex];
-            func_800518F8(objectIndex, object->unk_09C, (var_s5 - object->unk_09E) / 2);
+            render_clouds(objectIndex, object->unk_09C, (var_s5 - object->unk_09E) / 2);
         }
     }
 }
 
 void func_80051EBC(void) {
-    func_80051ABC(240 - D_800DC5EC->cameraHeight, 0); // 28
+    func_80051ABC(SCREEN_HEIGHT - D_800DC5EC->cameraHeight, 0); // 28
 }
 
 void func_80051EF8(void) {

--- a/src/render_objects.h
+++ b/src/render_objects.h
@@ -318,7 +318,7 @@ void func_80050E34(s32, s32);
 void func_800514BC(void);
 void render_object_leaf_particle(s32);
 void render_object_snowflakes_particles(void);
-void func_800518F8(s32, s16, s16);
+void render_clouds(s32, s16, s16);
 void func_800519D4(s32, s16, s16);
 void func_80051ABC(s16, s32);
 void func_80051C60(s16, s32);

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -1527,7 +1527,7 @@ void render_player_shadow(Player* player, s8 playerId, s8 screenId) {
 
     // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxShadow[playerId + (screenId * 8)]),
     //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    AddShadowMatrix(mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    PushShadowMatrix(mtx, playerId + (screenId * 8), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     gSPDisplayList(gDisplayListHead++, D_0D008D58);
     gDPSetTextureLUT(gDisplayListHead++, G_TT_NONE);
@@ -1579,7 +1579,7 @@ void render_player_shadow_credits(Player* player, s8 playerId, s8 arg2) {
     // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxShadow[playerId + (arg2 * 8)]),
     //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
-    AddShadowMatrix(mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    PushShadowMatrix(mtx, playerId + (arg2 * 8), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     gSPDisplayList(gDisplayListHead++, D_0D008D58);
     gDPSetTextureLUT(gDisplayListHead++, G_TT_NONE);
@@ -1659,7 +1659,7 @@ void render_kart(Player* player, s8 playerId, s8 screenId, s8 flipOffset) {
 
     if ((player->effects & BOO_EFFECT) == BOO_EFFECT) {
         if (screenId == playerId) {
-            AddKartMatrix(mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            PushKartMatrix(mtx, playerId + (screenId * 8), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(gDisplayListHead++, common_setting_render_character);
             gDPLoadTLUT_pal256(gDisplayListHead++, gPlayerPalette);
             gDPSetTextureLUT(gDisplayListHead++, G_TT_RGBA16);
@@ -1674,7 +1674,7 @@ void render_kart(Player* player, s8 playerId, s8 screenId, s8 flipOffset) {
         } else {
             // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxKart[playerId + (screenId * 8)]),
             //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            AddKartMatrix(mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+            PushKartMatrix(mtx, playerId + (screenId * 8), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(gDisplayListHead++, common_setting_render_character);
             gDPLoadTLUT_pal256(gDisplayListHead++, gPlayerPalette);
             gDPSetTextureLUT(gDisplayListHead++, G_TT_RGBA16);
@@ -1691,7 +1691,7 @@ void render_kart(Player* player, s8 playerId, s8 screenId, s8 flipOffset) {
                (player->soundEffects & 0x04000000)) {
         // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxKart[playerId + (screenId * 8)]),
         //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        AddKartMatrix(mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        PushKartMatrix(mtx, playerId + (screenId * 8), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(gDisplayListHead++, common_setting_render_character);
         gDPLoadTLUT_pal256(gDisplayListHead++, gPlayerPalette);
         gDPSetTextureLUT(gDisplayListHead++, G_TT_RGBA16);
@@ -1703,7 +1703,7 @@ void render_kart(Player* player, s8 playerId, s8 screenId, s8 flipOffset) {
     } else {
         // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxKart[playerId + (screenId * 8)]),
         //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        AddKartMatrix(mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        PushKartMatrix(mtx, playerId + (screenId * 8), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPDisplayList(gDisplayListHead++, common_setting_render_character);
         gDPLoadTLUT_pal256(gDisplayListHead++, gPlayerPalette);
         gDPSetTextureLUT(gDisplayListHead++, G_TT_RGBA16);
@@ -1772,7 +1772,7 @@ void render_ghost(Player* player, s8 playerId, s8 screenId, s8 flipOffset) {
 
     // gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxKart[playerId + (screenId * 8)]),
     //           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    AddKartMatrix(mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    PushKartMatrix(mtx, playerId + (screenId * 8), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     gSPDisplayList(gDisplayListHead++, common_setting_render_character);
     gDPLoadTLUT_pal256(gDisplayListHead++, gPlayerPalette);


### PR DESCRIPTION
This PR requires testing prior to merge. Once this PR has been confirmed good. All of the matrix stack calls will be renamed and combined into a single push matrix function.

* HM_Intro needs these fixes as well

* Fixes flashy text at start of racing disappearing
* Hopefully most the vtx stretching.

Resolves https://github.com/HarbourMasters/SpaghettiKart/issues/518 and https://github.com/HarbourMasters/SpaghettiKart/issues/296

It turns out some of the code wants to re-use the same mtx every frame, as such some matrices are reserved at the start of the frame.