### PR TITLE
Combine Matrix Stacks & use std::deque Instead of std::vector to Prevent Dangling Pointers

### DIFF
--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -544,9 +544,10 @@ void render_object(u32 arg0) {
 
 void render_object_p1(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
+
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_ONE),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_ONE),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
 
     // if (gGamestate == ENDING) {
@@ -562,9 +563,9 @@ void render_object_p1(void) {
 void render_object_p2(void) {
 
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[1]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_TWO),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[1]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_TWO),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     // render_bomb_karts_wrap(PLAYER_TWO);
     render_object_for_player(PLAYER_TWO);
@@ -572,9 +573,9 @@ void render_object_p2(void) {
 
 void render_object_p3(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[2]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_THREE),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[2]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_THREE),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     // render_bomb_karts_wrap(PLAYER_THREE);
     render_object_for_player(PLAYER_THREE);
@@ -583,9 +584,9 @@ void render_object_p3(void) {
 void render_object_p4(void) {
 
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[3]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_FOUR),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[3]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_FOUR),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     // render_bomb_karts_wrap(PLAYER_FOUR);
     if ((!gDemoMode) && (gPlayerCountSelection1 == 4)) {
@@ -639,9 +640,9 @@ void render_player_snow_effect(u32 arg0) {
 
 void render_player_snow_effect_one(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_ONE),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_ONE),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     if (gGamestate != ENDING) {
         render_snowing_effect(PLAYER_ONE);
@@ -650,27 +651,27 @@ void render_player_snow_effect_one(void) {
 
 void render_player_snow_effect_two(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[1]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_TWO),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[1]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_TWO),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     render_snowing_effect(PLAYER_TWO);
 }
 
 void render_player_snow_effect_three(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[2]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_THREE),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[2]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_THREE),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     render_snowing_effect(PLAYER_THREE);
 }
 
 void render_player_snow_effect_four(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[3]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_FOUR),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[3]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_FOUR),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     render_snowing_effect(PLAYER_FOUR);
 }

--- a/src/ending/code_80280000.c
+++ b/src/ending/code_80280000.c
@@ -57,13 +57,13 @@ void func_80280038(void) {
     func_80057FC4(0);
 
     gSPSetGeometryMode(gDisplayListHead++, G_ZBUFFER | G_SHADE | G_CULL_BACK | G_SHADING_SMOOTH);
-    guPerspective(&gGfxPool->mtxPersp[0], &perspNorm, gCameraZoom[0], gScreenAspect, CM_GetProps()->NearPersp, CM_GetProps()->FarPersp, 1.0f);
+    guPerspective(GetPerspMatrix(0), &perspNorm, gCameraZoom[0], gScreenAspect, CM_GetProps()->NearPersp, CM_GetProps()->FarPersp, 1.0f);
     gSPPerspNormalize(gDisplayListHead++, perspNorm);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(0),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    guLookAt(&gGfxPool->mtxLookAt[0], camera->pos[0], camera->pos[1], camera->pos[2], camera->lookAt[0],
+    guLookAt(GetLookAtMatrix(0), camera->pos[0], camera->pos[1], camera->pos[2], camera->lookAt[0],
              camera->lookAt[1], camera->lookAt[2], camera->up[0], camera->up[1], camera->up[2]);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(0),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     gCurrentCourseId = gCreditsCourseId;
     SetCourseById(gCreditsCourseId);

--- a/src/ending/code_80281C40.c
+++ b/src/ending/code_80281C40.c
@@ -15,6 +15,7 @@
 #include "defines.h"
 #include "memory.h"
 
+#include "engine/Matrix.h"
 #include "engine/courses/Course.h"
 #include "port/Game.h"
 
@@ -72,14 +73,14 @@ void func_80281D00(void) {
     }
     func_8028150C();
     gSPSetGeometryMode(gDisplayListHead++, G_ZBUFFER | G_SHADE | G_CULL_BACK | G_SHADING_SMOOTH);
-    guPerspective((Mtx*) &gGfxPool->mtxPersp[0], &perspNorm, gCameraZoom[0], gScreenAspect, CM_GetProps()->NearPersp, CM_GetProps()->FarPersp,
+    guPerspective(GetPerspMatrix(0), &perspNorm, gCameraZoom[0], gScreenAspect, CM_GetProps()->NearPersp, CM_GetProps()->FarPersp,
                   1.0f);
     gSPPerspNormalize(gDisplayListHead++, perspNorm);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(0),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    guLookAt((Mtx*) &gGfxPool->mtxLookAt[0], camera->pos[0], camera->pos[1], camera->pos[2], camera->lookAt[0],
+    guLookAt(GetLookAtMatrix(0), camera->pos[0], camera->pos[1], camera->pos[2], camera->lookAt[0],
              camera->lookAt[1], camera->lookAt[2], camera->up[0], camera->up[1], camera->up[2]);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(0),
               G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     mtxf_identity(matrix);
     render_set_position(matrix, 0);

--- a/src/engine/HM_Intro.cpp
+++ b/src/engine/HM_Intro.cpp
@@ -2,6 +2,7 @@
 #include <libultra/gu.h>
 #include "HM_Intro.h"
 
+#include "engine/Matrix.h"
 #include "port/Game.h"
 #include "port/interpolation/FrameInterpolation.h"
 
@@ -119,8 +120,6 @@ void HarbourMastersIntro::HM_DrawIntro() {
     //FrameInterpolation_ShouldInterpolateFrame(false);
     HarbourMastersIntro::Setup();
 
-    gSPMatrix(gDisplayListHead++, &gGfxPool->mtxScreen, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, &gGfxPool->mtxLookAt[0], G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
     gDPSetRenderMode(gDisplayListHead++, G_RM_AA_ZB_OPA_SURF, G_RM_AA_ZB_OPA_SURF2);
     gDPSetEnvColor(gDisplayListHead++, 0x00, 0x00, 0x00, 0x00);
 
@@ -170,11 +169,18 @@ void HarbourMastersIntro::HM_DrawIntro() {
 
 void HarbourMastersIntro::Setup() {
     u16 perspNorm;
+    
     move_segment_table_to_dmem();
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    guPerspective(&gGfxPool->mtxScreen, &perspNorm, 45.0f, 1.3333334f, 100.0f, 12800.0f, 1.0f);
+    
+    // Setup camera perspective
+    guPerspective(GetPerspMatrix(0), &perspNorm, 45.0f, 1.3333334f, 100.0f, 12800.0f, 1.0f);
     gSPPerspNormalize(gDisplayListHead++, perspNorm);
-    guLookAt(&gGfxPool->mtxLookAt[0], _camera.Pos.x, _camera.Pos.y, _camera.Pos.z, _camera.LookAt.x, _camera.LookAt.y, _camera.LookAt.z, 0.0f, 1.0f, 0.0f);
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(0), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+
+    // Setup camera lookAt
+    guLookAt(GetLookAtMatrix(0), _camera.Pos.x, _camera.Pos.y, _camera.Pos.z, _camera.LookAt.x, _camera.LookAt.y, _camera.LookAt.z, 0.0f, 1.0f, 0.0f);
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(0), G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
 
     gDPSetCycleType(gDisplayListHead++, G_CYC_FILL);
     gDPSetRenderMode(gDisplayListHead++, G_RM_OPA_SURF, G_RM_OPA_SURF2);

--- a/src/engine/Matrix.cpp
+++ b/src/engine/Matrix.cpp
@@ -21,25 +21,14 @@ void AddMatrix(std::deque<Mtx>& stack, Mat4 mtx, s32 flags) {
     gSPMatrix(gDisplayListHead++, &stack.back(), flags);
 }
 
-void AddMatrixVec(std::vector<Mtx>& stack, Mat4 mtx, s32 flags) {
-    // Push a new matrix to the stack
-    stack.emplace_back();
-
-    // Convert to a fixed-point matrix
-    FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &stack.back());
-    guMtxF2L(mtx, &stack.back());
-
-    // Load the matrix
-    gSPMatrix(gDisplayListHead++, &stack.back(), flags);
-}
-
 Mtx* GetMatrix(std::deque<Mtx>& stack) {
     stack.emplace_back();
     return &stack.back();
 }
 
 /**
- * Use GetMatrix() first
+ * Push a fixed point matrix to the stack
+ * Use GetMatrix() before calling this
  */
 void AddMatrixFixed(std::deque<Mtx>& stack, s32 flags) {
     // Load the matrix
@@ -70,14 +59,14 @@ void SetTextMatrix(Mat4 mf, f32 x, f32 y, f32 arg3, f32 arg4) {
 // AddMatrix but with custom gfx ptr arg and flags are predefined
 Gfx* AddTextMatrix(Gfx* displayListHead, Mat4 mtx) {
     // Push a new matrix to the stack
-    gWorldInstance.Mtx.Effects.emplace_back();
+    gWorldInstance.Mtx.Objects.emplace_back();
 
     // Convert to a fixed-point matrix
-    FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &gWorldInstance.Mtx.Effects.back());
-    guMtxF2L(mtx, &gWorldInstance.Mtx.Effects.back());
+    FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &gWorldInstance.Mtx.Objects.back());
+    guMtxF2L(mtx, &gWorldInstance.Mtx.Objects.back());
 
     // Load the matrix
-    gSPMatrix(displayListHead++, &gWorldInstance.Mtx.Effects.back(), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(displayListHead++, &gWorldInstance.Mtx.Objects.back(), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     return displayListHead;
 }
@@ -157,39 +146,43 @@ void AddLocalRotation(Mat4 mat, IRotator rot) {
 extern "C" {
 
     void AddHudMatrix(Mat4 mtx, s32 flags) {
-    AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
+        AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
-    void AddPerspMatrix(Mat4 mtx, s32 flags) {
-        AddMatrixVec(gWorldInstance.Mtx.Persp, mtx, flags);
+    Mtx* GetScreenMatrix(void) {
+        return &gWorldInstance.Mtx.Screen2D;
     }
 
-    void AddLookAtMatrix(Mat4 mtx, s32 flags) {
-        AddMatrixVec(gWorldInstance.Mtx.LookAt, mtx, flags);
+    Mtx* GetOrthoMatrix(void) {
+        return &gWorldInstance.Mtx.Ortho;
+    }
+
+    Mtx* GetPerspMatrix(size_t cameraId) {
+        return &gWorldInstance.Mtx.Persp[cameraId];
+    }
+
+    Mtx* GetLookAtMatrix(size_t cameraId) {
+        return &gWorldInstance.Mtx.LookAt[cameraId];
     }
 
     void AddObjectMatrix(Mat4 mtx, s32 flags) {
         AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
-    void AddShadowMatrix(Mat4 mtx, s32 flags) {
-        AddMatrixVec(gWorldInstance.Mtx.Shadows, mtx, flags);
+    Mtx* GetShadowMatrix(size_t playerId) {
+        return &gWorldInstance.Mtx.Shadows[playerId];
     }
 
-    void AddKartMatrix(Mat4 mtx, s32 flags) {
-        AddMatrixVec(gWorldInstance.Mtx.Karts, mtx, flags);
+    Mtx* GetKartMatrix(size_t playerId) {
+        return &gWorldInstance.Mtx.Karts[playerId];
     }
 
     void AddEffectMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(gWorldInstance.Mtx.Effects, mtx, flags);
-    }
-
-    void AddEffectMatrixFixed(s32 flags) {
-        AddMatrixFixed(gWorldInstance.Mtx.Effects, flags);
+        AddMatrix(gWorldInstance.Mtx.Objects, mtx, flags);
     }
 
     void AddEffectMatrixOrtho(void) {
-        auto& stack = gWorldInstance.Mtx.Effects;
+        auto& stack = gWorldInstance.Mtx.Objects;
         stack.emplace_back();
 
         guOrtho(&stack.back(), 0.0f, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1, 0.0f, -100.0f, 100.0f, 1.0f);
@@ -198,7 +191,7 @@ extern "C" {
     }
 
     Mtx* GetEffectMatrix(void) {
-        return GetMatrix(gWorldInstance.Mtx.Effects);
+        return GetMatrix(gWorldInstance.Mtx.Objects);
     }
 
 
@@ -207,18 +200,10 @@ extern "C" {
      * We might need to adjust which ones we clear.
      */
     void ClearMatrixPools(void) {
-        gWorldInstance.Mtx.Hud.clear();
         gWorldInstance.Mtx.Objects.clear();
-        gWorldInstance.Mtx.Shadows.clear();
-        gWorldInstance.Mtx.Karts.clear();
-        gWorldInstance.Mtx.Effects.clear();
-    }
-
-    void ClearHudMatrixPool(void) {
-        gWorldInstance.Mtx.Hud.clear();
-    }
-    void ClearEffectsMatrixPool(void) {
-        gWorldInstance.Mtx.Effects.clear();
+       // gWorldInstance.Mtx.Shadows.clear();
+        //gWorldInstance.Mtx.Karts.clear();
+       // gWorldInstance.Mtx.Effects.clear();
     }
 
     void ClearObjectsMatrixPool(void) {

--- a/src/engine/Matrix.h
+++ b/src/engine/Matrix.h
@@ -16,15 +16,20 @@ void AddHudMatrix(Mat4 mtx, s32 flags);
 void AddObjectMatrix(Mat4 mtx, s32 flags);
 void AddEffectMatrix(Mat4 mtx, s32 flags);
 void AddEffectMatrixOrtho(void);
-void AddEffectMatrixFixed(s32 flags);
+
+Mtx* GetScreenMatrix(void); // Orthogonal projection for UI, skybox, etc.
+Mtx* GetOrthoMatrix(void);
+Mtx* GetPerspMatrix(size_t cameraId);
+Mtx* GetLookAtMatrix(size_t cameraId);
+
+Mtx* GetKartMatrix(size_t playerId);
+Mtx* GetShadowMatrix(size_t playerId);
+
 void SetTextMatrix(Mat4 mf, f32 arg1, f32 arg2, f32 arg3, f32 arg4);
 Gfx* AddTextMatrix(Gfx* displayListHead, Mat4 mtx);
 Mtx* GetEffectMatrix(void);
-void ClearHudMatrixPool(void);
-void ClearEffectsMatrixPool(void);
 void ClearObjectsMatrixPool(void);
 void AddKartMatrix(Mat4 mtx, s32 flags);
-void AddShadowMatrix(Mat4 mtx, s32 flags);
 
 #ifdef __cplusplus
 }

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -41,17 +41,17 @@ class GameObject; // <-- Editor
 
 class World {
 typedef struct Matrix {
+    Mtx Screen2D; // Orthogonal projection for UI, skybox, and such
+    Mtx Ortho;
+    std::array<Mtx,4> Persp;
+    std::array<Mtx,4> LookAt;
+    std::array<Mtx, 8 * 4> Karts; // Eight players * four screens
+    std::array<Mtx, 8 * 4> Shadows; // Eight players * four screens
     std::deque<Mtx> Hud;
     std::deque<Mtx> Objects;
-    std::vector<Mtx> Shadows;
-    std::vector<Mtx> Karts;
-    std::deque<Mtx> Effects;
-    std::vector<Mtx> Persp;
-    std::vector<Mtx> LookAt;
 
     Matrix()
-        : Hud(100), Objects(1000), Shadows(32),
-          Karts(32), Effects(1000), Persp(4), LookAt(4)
+        : Hud(200), Objects(1000)
     {}
 };
 

--- a/src/engine/objects/Trophy.cpp
+++ b/src/engine/objects/Trophy.cpp
@@ -221,9 +221,9 @@ void OTrophy::Draw(s32 cameraId) {
     if (*_toggleVisibility == true) {
         object = &gObjectList[listIndex];
         if (object->state >= 2) {
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[0]),
+            gSPMatrix(gDisplayListHead++, GetPerspMatrix(0),
                     G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
+            gSPMatrix(gDisplayListHead++, GetLookAtMatrix(0),
                     G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             mtxf_set_matrix_transformation(someMatrix1, object->pos, object->direction_angle, object->sizeScaling);
             //convert_to_fixed_point_matrix(&gGfxPool->mtxHud[gMatrixHudCount], someMatrix1);
@@ -234,7 +234,7 @@ void OTrophy::Draw(s32 cameraId) {
 
             gSPDisplayList(gDisplayListHead++, (Gfx*)D_0D0077A0);
             gSPDisplayList(gDisplayListHead++, object->model);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[0]),
+            gSPMatrix(gDisplayListHead++, GetLookAtMatrix(0),
                     G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             mtxf_identity(someMatrix2);
             render_set_position(someMatrix2, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -803,7 +803,6 @@ void process_game_tick(void) {
 void race_logic_loop(void) {
     ClearMatrixPools();
     ClearObjectsMatrixPool();
-    ClearEffectsMatrixPool();
     Editor_ClearMatrix();
     gMatrixObjectCount = 0;
     gMatrixEffectCount = 0;

--- a/src/math_util_2.c
+++ b/src/math_util_2.c
@@ -610,27 +610,27 @@ void func_80041D34(void) {
     guOrtho(&D_80183D60, 0.0f, 320.0f, 240.0f, 0.0f, -1.0f, 1.0f, 1.0f);
     switch (gActiveScreenMode) {
         case SCREEN_MODE_1P:
-            guOrtho(&gGfxPool->mtxOrtho, 0.0f, 320.0f, 240.0f, 0.0f, -1.0f, 1.0f, 1.0f);
+            guOrtho(GetOrthoMatrix(), 0.0f, 320.0f, 240.0f, 0.0f, -1.0f, 1.0f, 1.0f);
             break;
         case SCREEN_MODE_2P_SPLITSCREEN_VERTICAL:
-            guOrtho(&gGfxPool->mtxOrtho, 0.0f, 160.0f, 120.0f, 0.0f, -1.0f, 1.0f, 1.0f);
+            guOrtho(GetOrthoMatrix(), 0.0f, 160.0f, 120.0f, 0.0f, -1.0f, 1.0f, 1.0f);
             break;
         case SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL:
             if (D_801658FE == 0) {
-                guOrtho(&gGfxPool->mtxOrtho, 0.0f, 320.0f, 120.0f, 0.0f, -1.0f, 1.0f, 1.0f);
+                guOrtho(GetOrthoMatrix(), 0.0f, 320.0f, 120.0f, 0.0f, -1.0f, 1.0f, 1.0f);
             } else {
-                guOrtho(&gGfxPool->mtxOrtho, 0.0f, 320.0f, 240.0f, 0.0f, -1.0f, 1.0f, 1.0f);
+                guOrtho(GetOrthoMatrix(), 0.0f, 320.0f, 240.0f, 0.0f, -1.0f, 1.0f, 1.0f);
             }
             break;
         case SCREEN_MODE_3P_4P_SPLITSCREEN:
-            guOrtho(&gGfxPool->mtxOrtho, 0.0f, 320.0f, 240.0f, 0.0f, -1.0f, 1.0f, 1.0f);
+            guOrtho(GetOrthoMatrix(), 0.0f, 320.0f, 240.0f, 0.0f, -1.0f, 1.0f, 1.0f);
             break;
     }
 }
 
 void set_matrix_hud_screen(void) {
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxOrtho),
+    gSPMatrix(gDisplayListHead++, GetOrthoMatrix(),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
 }
 

--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -2438,7 +2438,7 @@ void func_80093C98(s32 arg0) {
         func_8009CA6C(4);
         D_80165754 = gMatrixEffectCount;
         gMatrixEffectCount = 0;
-        ClearEffectsMatrixPool();
+        // ClearEffectsMatrixPool();
     }
 }
 
@@ -2491,7 +2491,7 @@ void func_80093F10(void) {
     func_8009CA2C();
     gSPDisplayList(gDisplayListHead++, D_02007F48);
     gMatrixEffectCount = 0;
-    ClearEffectsMatrixPool();
+    // ClearEffectsMatrixPool();
 }
 
 void func_800940EC(s32 arg0) {
@@ -2521,8 +2521,8 @@ void func_800942D0(void) {
     s32 i;
     s32 alpha;
 
-    gSPMatrix(gDisplayListHead++, &gGfxPool->mtxScreen, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, &gGfxPool->mtxLookAt[0], G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(0), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(0), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     guRotate(mtx, gIntroModelRotX, 1.0f, 0.0f, 0.0f);
     guRotate(mtx + 1, gIntroModelRotY, 0.0f, 1.0f, 0.0f);
     guScale(mtx + 2, 1.0f, 1.0f, gIntroModelScale);
@@ -2560,9 +2560,9 @@ void func_80094660(struct GfxPool* arg0, UNUSED s32 arg1) {
 
     move_segment_table_to_dmem();
     gDPSetTexturePersp(gDisplayListHead++, G_TP_PERSP);
-    guPerspective(&arg0->mtxScreen, &perspNorm, 45.0f, 1.3333334f, 100.0f, 12800.0f, 1.0f);
+    guPerspective(GetPerspMatrix(0), &perspNorm, 45.0f, 1.3333334f, 100.0f, 12800.0f, 1.0f);
     gSPPerspNormalize(gDisplayListHead++, perspNorm);
-    guLookAt(&arg0->mtxLookAt[0], 0.0f, 0.0f, (f32) gIntroModelZEye, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f);
+    guLookAt(GetLookAtMatrix(0), 0.0f, 0.0f, (f32) gIntroModelZEye, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f);
     func_800942D0();
     gDPPipeSync(gDisplayListHead++);
     gDPSetTexturePersp(gDisplayListHead++, G_TP_NONE);
@@ -2573,16 +2573,16 @@ void render_checkered_flag(struct GfxPool* arg0, UNUSED s32 arg1) {
     u16 perspNorm;
 
     move_segment_table_to_dmem();
-    guPerspective(&arg0->mtxPersp[0], &perspNorm, 45.0f, 1.3333334f, 100.0f, 12800.0f, 1.0f);
+    guPerspective(GetPerspMatrix(0), &perspNorm, 45.0f, 1.3333334f, 100.0f, 12800.0f, 1.0f);
     gSPPerspNormalize(gDisplayListHead++, perspNorm);
-    guLookAt(&arg0->mtxLookAt[1], 0.0f, 0.0f, (f32) gIntroModelZEye, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f);
+    guLookAt(GetLookAtMatrix(1), 0.0f, 0.0f, (f32) gIntroModelZEye, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f);
     guRotate(&arg0->mtxObject[0], gIntroModelRotX, 1.0f, 0, 0);
     guRotate(&arg0->mtxObject[1], gIntroModelRotY, 0, 1.0f, 0);
     guRotate(&arg0->mtxObject[2], gIntroModelRotZ, 0, 0, 1.0f);
     guScale(&arg0->mtxObject[3], gIntroModelScale, gIntroModelScale, gIntroModelScale);
     guTranslate(&arg0->mtxObject[4], gIntroModelPosX, gIntroModelPosY, gIntroModelPosZ);
-    gSPMatrix(gDisplayListHead++, &arg0->mtxPersp[0], G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-    gSPMatrix(gDisplayListHead++, &arg0->mtxLookAt[1], G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(gDisplayListHead++, GetPerspMatrix(0), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    gSPMatrix(gDisplayListHead++, GetLookAtMatrix(1), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPMatrix(gDisplayListHead++, &arg0->mtxObject[0], G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
     gSPMatrix(gDisplayListHead++, &arg0->mtxObject[1], G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
     gSPMatrix(gDisplayListHead++, &arg0->mtxObject[2], G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
@@ -2594,14 +2594,13 @@ void render_checkered_flag(struct GfxPool* arg0, UNUSED s32 arg1) {
 }
 
 void func_80094A64(struct GfxPool* pool) {
-    ClearHudMatrixPool();
-    ClearEffectsMatrixPool();
+    ClearObjectsMatrixPool();
     gMatrixHudCount = 0;
     gMatrixEffectCount = 0;
     gSPViewport(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(D_802B8880));
     gDPSetScissor(gDisplayListHead++, G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-    guOrtho(&pool->mtxScreen, 0.0f, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1, 0.0f, -100.0f, 100.0f, 1.0f);
-    gSPMatrix(gDisplayListHead++, &pool->mtxScreen, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
+    guOrtho(GetScreenMatrix(), 0.0f, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1, 0.0f, -100.0f, 100.0f, 1.0f);
+    gSPMatrix(gDisplayListHead++, GetScreenMatrix(), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
     gSPDisplayList(gDisplayListHead++, D_02007650);
     setup_menus();
     func_80092290(4, D_8018E850, D_8018E858);

--- a/src/player_controller.c
+++ b/src/player_controller.c
@@ -684,7 +684,7 @@ UNUSED void func_80028F5C(UNUSED s32 arg0, UNUSED s32 arg1, UNUSED s32 arg2, UNU
 }
 
 void func_80028F70(void) {
-    ClearEffectsMatrixPool();
+    // ClearEffectsMatrixPool();
     gMatrixEffectCount = 0;
     func_80028E70(gPlayerOne, camera1, 0, 0);
     func_80028E70(gPlayerTwo, camera1, 1, 0);
@@ -697,7 +697,7 @@ void func_80028F70(void) {
 }
 
 void func_80029060(void) {
-    ClearEffectsMatrixPool();
+    // ClearEffectsMatrixPool();
     gMatrixEffectCount = 0;
     func_80028E70(gPlayerOne, camera1, 0, 0);
     func_80028E70(gPlayerTwo, camera1, 1, 0);
@@ -713,7 +713,7 @@ void func_80029150(void) {
 }
 
 void func_80029158(void) {
-    ClearEffectsMatrixPool();
+    // ClearEffectsMatrixPool();
     gMatrixEffectCount = 0;
     func_80028E70(gPlayerOne, camera1, 0, 0);
     func_80028E70(gPlayerTwo, camera1, 1, 0);

--- a/src/port/interpolation/FrameInterpolation.h
+++ b/src/port/interpolation/FrameInterpolation.h
@@ -22,6 +22,9 @@ extern "C" {
 #define TAG_SMOKE_DUST(x) ((u32) 0x20000000 | (u32) (x))
 #define TAG_LETTER(x) ((u32)0x30000000 | (u32) (uintptr_t) (x))
 #define TAG_OBJECT(x) ((u32)0x40000000 | (u32) (uintptr_t) (x))
+#define TAG_CLOUDS(x) ((u32)0x50000000 | (u32) (uintptr_t) (x))
+//                          Mask the bits so that the 7 can't get overridden
+#define TAG_TRACK(x) ((u32)0x70000000 | ((u32)(x) & 0x0FFFFFFF))
 
 void FrameInterpolation_ShouldInterpolateFrame(bool shouldInterpolate);
 

--- a/src/racing/render_courses.c
+++ b/src/racing/render_courses.c
@@ -22,6 +22,7 @@
 #include "courses/all_course_packed.h"
 #include "courses/all_course_offsets.h"
 #include "port/Game.h"
+#include "engine/Matrix.h"
 #include "engine/courses/Course.h"
 
 #include "enhancements/collision_viewer.h"
@@ -215,29 +216,34 @@ void func_8029122C(struct UnkStruct_800DC5EC* arg0, s32 playerId) {
     pathCounter = (u16) arg0->pathCounter;
     cameraRot = (u16) arg0->camera->rot[1];
     playerDirection = arg0->playerDirection;
+
+    // This pushes the camera matrices to the top of the stack.
+    // It does not appear to really do anything.
+    // Perhaps they thought it was necessary to set the camera back to projection mode since rainbow road uses model mode.
+    // But that issue should be cleared up in render_screens() already.
     switch (playerId) {
         case PLAYER_ONE:
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_ONE]),
+            gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_ONE),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_ONE]),
+            gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_ONE),
                       G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             break;
         case PLAYER_TWO:
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_TWO]),
+            gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_TWO),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_TWO]),
+            gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_TWO),
                       G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             break;
         case PLAYER_THREE:
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_THREE]),
+            gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_THREE),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_THREE]),
+            gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_THREE),
                       G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             break;
         case PLAYER_FOUR:
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxPersp[PLAYER_FOUR]),
+            gSPMatrix(gDisplayListHead++, GetPerspMatrix(PLAYER_FOUR),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_PROJECTION);
-            gSPMatrix(gDisplayListHead++, VIRTUAL_TO_PHYSICAL(&gGfxPool->mtxLookAt[PLAYER_FOUR]),
+            gSPMatrix(gDisplayListHead++, GetLookAtMatrix(PLAYER_FOUR),
                       G_MTX_NOPUSH | G_MTX_MUL | G_MTX_PROJECTION);
             break;
     }

--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -3484,7 +3484,7 @@ struct ObjectInterpData {
 
 struct ObjectInterpData prevObject[OBJECT_LIST_SIZE] = { 0 };
 
-void func_800518F8(s32 objectIndex, s16 x, s16 y) {
+void render_clouds(s32 objectIndex, s16 x, s16 y) {
 
     // Search all recorded objects for the one we're drawing
     for (size_t i = 0; i < OBJECT_LIST_SIZE; i++) {
@@ -3503,7 +3503,7 @@ void func_800518F8(s32 objectIndex, s16 x, s16 y) {
     if (gObjectList[objectIndex].status & 0x10) {
 
         // @port: Tag the transform.
-        FrameInterpolation_RecordOpenChild("func_800518F8", (uintptr_t) &gObjectList[objectIndex]);
+        FrameInterpolation_RecordOpenChild("render_clouds", TAG_CLOUDS(objectIndex));
 
         if (D_8018D228 != gObjectList[objectIndex].unk_0D5) {
             D_8018D228 = gObjectList[objectIndex].unk_0D5;
@@ -3562,13 +3562,7 @@ void func_80051ABC(s16 arg0, s32 arg1) {
             objectIndex = D_8018CC80[arg1 + var_s0];
             object = &gObjectList[objectIndex];
 
-            // @port: Tag the transform.
-            FrameInterpolation_RecordOpenChild("func_80051ABC", TAG_OBJECT(object));
-
-            func_800518F8(objectIndex, object->unk_09C, arg0 - object->unk_09E);
-
-            // @port Pop the transform id.
-            FrameInterpolation_RecordCloseChild();
+            render_clouds(objectIndex, object->unk_09C, arg0 - object->unk_09E);
         }
     }
 }
@@ -3610,7 +3604,7 @@ void func_80051C60(s16 arg0, s32 arg1) {
         for (var_s0 = 0; var_s0 < D_8018D1F0; var_s0++) {
             objectIndex = D_8018CC80[arg1 + var_s0];
             object = &gObjectList[objectIndex];
-            func_800518F8(objectIndex, object->unk_09C, (var_s5 - object->unk_09E) / 2);
+            render_clouds(objectIndex, object->unk_09C, (var_s5 - object->unk_09E) / 2);
         }
     }
 }

--- a/src/render_objects.h
+++ b/src/render_objects.h
@@ -318,7 +318,7 @@ void func_80050E34(s32, s32);
 void func_800514BC(void);
 void render_object_leaf_particle(s32);
 void render_object_snowflakes_particles(void);
-void func_800518F8(s32, s16, s16);
+void render_clouds(s32, s16, s16);
 void func_800519D4(s32, s16, s16);
 void func_80051ABC(s16, s32);
 void func_80051C60(s16, s32);


### PR DESCRIPTION
std::vector is not good for matrix stacks because when the vector reaches max size, the memory gets moved into a bigger block of memory. This invalidates the mtx pointers stored in the frame interpolation system.

Thus, std::deque promises the original pointers stay valid. The results in more ptr accesses since a dequeue is essentially a list of lists, but it's the best solution for now and it would be very surprising if there was any noticable performance decrease.

This should fix the following issues:

* HM_Intro

* Fixes flashy text at start of racing disappearing

* Hopefully most the vtx stretching.



Resolves https://github.com/HarbourMasters/SpaghettiKart/issues/518 and https://github.com/HarbourMasters/SpaghettiKart/issues/296