### PR TITLE
Replace FrameInterpolation Pop/Push with RecordOpen/CloseChild

### DIFF
--- a/src/actors/mario_sign/render.inc.c
+++ b/src/actors/mario_sign/render.inc.c
@@ -25,7 +25,7 @@ void render_actor_mario_sign(Camera* arg0, UNUSED Mat4 arg1, struct Actor* arg2)
     }
     if (!(unk < 0.0f)) {
 
-        FrameInterpolation_RecordOpenChild("mario_sign", TAG_OBJECT(mtx));
+        FrameInterpolation_RecordOpenChild("mario_sign", TAG_OBJECT(arg2));
 
         gSPSetGeometryMode(gDisplayListHead++, G_SHADING_SMOOTH);
         gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);

--- a/src/actors/mario_sign/render.inc.c
+++ b/src/actors/mario_sign/render.inc.c
@@ -25,7 +25,8 @@ void render_actor_mario_sign(Camera* arg0, UNUSED Mat4 arg1, struct Actor* arg2)
     }
     if (!(unk < 0.0f)) {
 
-    FrameInterpolation_RecordMatrixPush(mtx);
+        // FrameInterpolation_RecordMatrixPush(mtx);
+        FrameInterpolation_RecordOpenChild("mario_sign", TAG_OBJECT(mtx));
 
         gSPSetGeometryMode(gDisplayListHead++, G_SHADING_SMOOTH);
         gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);
@@ -33,7 +34,7 @@ void render_actor_mario_sign(Camera* arg0, UNUSED Mat4 arg1, struct Actor* arg2)
         if (render_set_position(mtx, 0) != 0) {
             gSPDisplayList(gDisplayListHead++, d_course_mario_raceway_dl_sign);
         }
-    FrameInterpolation_RecordMatrixPop(mtx);
-
+        // FrameInterpolation_RecordMatrixPop(mtx);
+        FrameInterpolation_RecordCloseChild();
     }
 }

--- a/src/actors/mario_sign/render.inc.c
+++ b/src/actors/mario_sign/render.inc.c
@@ -25,7 +25,6 @@ void render_actor_mario_sign(Camera* arg0, UNUSED Mat4 arg1, struct Actor* arg2)
     }
     if (!(unk < 0.0f)) {
 
-        // FrameInterpolation_RecordMatrixPush(mtx);
         FrameInterpolation_RecordOpenChild("mario_sign", TAG_OBJECT(mtx));
 
         gSPSetGeometryMode(gDisplayListHead++, G_SHADING_SMOOTH);
@@ -34,7 +33,6 @@ void render_actor_mario_sign(Camera* arg0, UNUSED Mat4 arg1, struct Actor* arg2)
         if (render_set_position(mtx, 0) != 0) {
             gSPDisplayList(gDisplayListHead++, d_course_mario_raceway_dl_sign);
         }
-        // FrameInterpolation_RecordMatrixPop(mtx);
         FrameInterpolation_RecordCloseChild();
     }
 }

--- a/src/actors/yoshi_egg/render.inc.c
+++ b/src/actors/yoshi_egg/render.inc.c
@@ -53,7 +53,8 @@ void render_actor_yoshi_egg(Camera* arg0, Mat4 arg1, struct YoshiValleyEgg* egg,
         sp5C[1] = egg->eggRot;
         sp5C[2] = 0;
 
-        FrameInterpolation_RecordMatrixPush(sp60);
+        //FrameInterpolation_RecordMatrixPush(sp60);
+        FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(sp60));
 
         mtxf_pos_rotation_xyz(sp60, egg->pos, sp5C);
         if (render_set_position(sp60, 0) == 0) {
@@ -62,18 +63,20 @@ void render_actor_yoshi_egg(Camera* arg0, Mat4 arg1, struct YoshiValleyEgg* egg,
 
         gSPSetGeometryMode(gDisplayListHead++, G_LIGHTING);
         gSPDisplayList(gDisplayListHead++, d_course_yoshi_valley_dl_16D70);
-        FrameInterpolation_RecordMatrixPop(sp60);
+        //FrameInterpolation_RecordMatrixPop(sp60);
     } else {
         arg1[3][0] = egg->pos[0];
         arg1[3][1] = egg->pos[1];
         arg1[3][2] = egg->pos[2];
 
-        FrameInterpolation_RecordMatrixPush(arg1);
+        //FrameInterpolation_RecordMatrixPush(arg1);
+        FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(arg1));
 
         if (render_set_position(arg1, 0) != 0) {
             gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);
             gSPDisplayList(gDisplayListHead++, d_course_yoshi_valley_dl_egg_lod0);
         }
-        FrameInterpolation_RecordMatrixPop(arg1);
+        //FrameInterpolation_RecordMatrixPop(arg1);
+        FrameInterpolation_RecordCloseChild();
     }
 }

--- a/src/actors/yoshi_egg/render.inc.c
+++ b/src/actors/yoshi_egg/render.inc.c
@@ -53,7 +53,6 @@ void render_actor_yoshi_egg(Camera* arg0, Mat4 arg1, struct YoshiValleyEgg* egg,
         sp5C[1] = egg->eggRot;
         sp5C[2] = 0;
 
-        //FrameInterpolation_RecordMatrixPush(sp60);
         FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(sp60));
 
         mtxf_pos_rotation_xyz(sp60, egg->pos, sp5C);
@@ -63,20 +62,18 @@ void render_actor_yoshi_egg(Camera* arg0, Mat4 arg1, struct YoshiValleyEgg* egg,
 
         gSPSetGeometryMode(gDisplayListHead++, G_LIGHTING);
         gSPDisplayList(gDisplayListHead++, d_course_yoshi_valley_dl_16D70);
-        //FrameInterpolation_RecordMatrixPop(sp60);
+        FrameInterpolation_RecordCloseChild();
     } else {
         arg1[3][0] = egg->pos[0];
         arg1[3][1] = egg->pos[1];
         arg1[3][2] = egg->pos[2];
 
-        //FrameInterpolation_RecordMatrixPush(arg1);
         FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(arg1));
 
         if (render_set_position(arg1, 0) != 0) {
             gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);
             gSPDisplayList(gDisplayListHead++, d_course_yoshi_valley_dl_egg_lod0);
         }
-        //FrameInterpolation_RecordMatrixPop(arg1);
         FrameInterpolation_RecordCloseChild();
     }
 }

--- a/src/actors/yoshi_egg/render.inc.c
+++ b/src/actors/yoshi_egg/render.inc.c
@@ -53,7 +53,7 @@ void render_actor_yoshi_egg(Camera* arg0, Mat4 arg1, struct YoshiValleyEgg* egg,
         sp5C[1] = egg->eggRot;
         sp5C[2] = 0;
 
-        FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(sp60));
+        FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(egg));
 
         mtxf_pos_rotation_xyz(sp60, egg->pos, sp5C);
         if (render_set_position(sp60, 0) == 0) {
@@ -68,7 +68,7 @@ void render_actor_yoshi_egg(Camera* arg0, Mat4 arg1, struct YoshiValleyEgg* egg,
         arg1[3][1] = egg->pos[1];
         arg1[3][2] = egg->pos[2];
 
-        FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(arg1));
+        FrameInterpolation_RecordOpenChild("yoshi_egg2", TAG_OBJECT(egg));
 
         if (render_set_position(arg1, 0) != 0) {
             gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);

--- a/src/animation.c
+++ b/src/animation.c
@@ -97,7 +97,7 @@ void render_limb_or_add_mtx(Armature* arg0, s16* arg1, AnimationLimbVector arg2,
         angle[i] = arg1[arg2[i].indexCycle + some_offset];
     }
     //FrameInterpolation_RecordMatrixPush(modelMatrix);
-    FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(modelMatrix));
+    FrameInterpolation_RecordOpenChild("", TAG_OBJECT(modelMatrix));
     mtxf_translate_rotate2(modelMatrix, pos, angle);
     //convert_to_fixed_point_matrix_animation(&gGfxPool->mtxHud[gMatrixHudCount], modelMatrix);
     sMatrixStackSize += 1;

--- a/src/animation.c
+++ b/src/animation.c
@@ -96,8 +96,7 @@ void render_limb_or_add_mtx(Armature* arg0, s16* arg1, AnimationLimbVector arg2,
         }
         angle[i] = arg1[arg2[i].indexCycle + some_offset];
     }
-    //FrameInterpolation_RecordMatrixPush(modelMatrix);
-    FrameInterpolation_RecordOpenChild("", TAG_OBJECT(modelMatrix));
+    FrameInterpolation_RecordOpenChild("animation", TAG_OBJECT(arg0));
     mtxf_translate_rotate2(modelMatrix, pos, angle);
     //convert_to_fixed_point_matrix_animation(&gGfxPool->mtxHud[gMatrixHudCount], modelMatrix);
     sMatrixStackSize += 1;
@@ -109,7 +108,6 @@ void render_limb_or_add_mtx(Armature* arg0, s16* arg1, AnimationLimbVector arg2,
         model = (virtualModel);
         gSPDisplayList(gDisplayListHead++, model);
     }
-    //FrameInterpolation_RecordMatrixPop(modelMatrix);
     FrameInterpolation_RecordCloseChild();
 }
 

--- a/src/animation.c
+++ b/src/animation.c
@@ -96,7 +96,8 @@ void render_limb_or_add_mtx(Armature* arg0, s16* arg1, AnimationLimbVector arg2,
         }
         angle[i] = arg1[arg2[i].indexCycle + some_offset];
     }
-    FrameInterpolation_RecordMatrixPush(modelMatrix);
+    //FrameInterpolation_RecordMatrixPush(modelMatrix);
+    FrameInterpolation_RecordOpenChild("yoshi_egg", TAG_OBJECT(modelMatrix));
     mtxf_translate_rotate2(modelMatrix, pos, angle);
     //convert_to_fixed_point_matrix_animation(&gGfxPool->mtxHud[gMatrixHudCount], modelMatrix);
     sMatrixStackSize += 1;
@@ -108,7 +109,8 @@ void render_limb_or_add_mtx(Armature* arg0, s16* arg1, AnimationLimbVector arg2,
         model = (virtualModel);
         gSPDisplayList(gDisplayListHead++, model);
     }
-    FrameInterpolation_RecordMatrixPop(modelMatrix);
+    //FrameInterpolation_RecordMatrixPop(modelMatrix);
+    FrameInterpolation_RecordCloseChild();
 }
 
 void render_armature(Armature* animation, Animation* arg1, s16 timeCycle) {

--- a/src/port/interpolation/FrameInterpolation.cpp
+++ b/src/port/interpolation/FrameInterpolation.cpp
@@ -686,13 +686,13 @@ void FrameInterpolation_RecordActorPosRotMatrix(void) {
     next_is_actor_pos_rot_matrix = true;
 }
 
-void FrameInterpolation_RecordMatrixPush(Mat4* matrix) {
-    if (!check_if_recording()) {
-        return;
-    }
-
-    append(Op::MatrixPush).matrix_ptr = { (Mat4**) matrix };
-}
+//void FrameInterpolation_RecordMatrixPush(Mat4* matrix) {
+//    if (!check_if_recording()) {
+//        return;
+//    }
+//
+//    append(Op::MatrixPush).matrix_ptr = { (Mat4**) matrix };
+//}
 
 void FrameInterpolation_RecordMarker(const char* file, int line) {
     if (!check_if_recording()) {
@@ -702,12 +702,12 @@ void FrameInterpolation_RecordMarker(const char* file, int line) {
     append(Op::Marker).marker = { file, line };
 }
 
-void FrameInterpolation_RecordMatrixPop(Mat4* matrix) {
-    if (!check_if_recording()) {
-        return;
-    }
-    append(Op::MatrixPop).matrix_ptr = { (Mat4**) matrix };
-}
+//void FrameInterpolation_RecordMatrixPop(Mat4* matrix) {
+//    if (!check_if_recording()) {
+//        return;
+//    }
+//    append(Op::MatrixPop).matrix_ptr = { (Mat4**) matrix };
+//}
 
 void FrameInterpolation_RecordMatrixPut(MtxF* src) {
     if (!check_if_recording()) {

--- a/src/port/interpolation/FrameInterpolation.h
+++ b/src/port/interpolation/FrameInterpolation.h
@@ -52,9 +52,9 @@ void FrameInterpolation_RecordMatrixPosRotScaleXY(Mat4* matrix, s32 x, s32 y, u1
 
 void FrameInterpolation_Record_SetTextMatrix(Mat4* matrix, f32 x, f32 y, f32 arg3, f32 arg4);
 
-void FrameInterpolation_RecordMatrixPush(Mat4* matrix);
+//void FrameInterpolation_RecordMatrixPush(Mat4* matrix);
 
-void FrameInterpolation_RecordMatrixPop(Mat4* matrix);
+//void FrameInterpolation_RecordMatrixPop(Mat4* matrix);
 
 void FrameInterpolation_RecordMatrixMult(Mat4* matrix, MtxF* mf, u8 mode);
 


### PR DESCRIPTION
From a message from MegaMech in the dev channel.
I commented out the Pop/Push functions just to make sure I wasn't missing them being used anywhere. Let me know if you want me to remove the commented code (or the functions completely).

Not being very familiar with how these functions work, I made a direct example of what MegaMech wrote in the development channel. There were two uses; for the yoshi egg (Yoshi Valley) and for the mario sign (Mario Raceway).

Compiled and tested. No clear issues like crashes or anything, but also not clear on what the original issue was, I admit :D 

I'm now sure about `animation.c`. Should that remain the same or also be replaced? I replaced it out of curiosity and couldn't tell immediately if something was different. Let me know if I should revert this file to use Pop/Push.