### PR TITLE
Added fades for 3P4P menuing

### DIFF
--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -5101,6 +5101,11 @@ void draw_fade_in(s32 arg0, s32 arg1, s32 arg2) {
                     color->green, color->blue,
                     0xFF - (gCurrentTransitionTime[arg0] * 0xFF / gTransitionDuration[arg0]));
             }
+            else if ((arg0 == 4)) {
+                gDisplayListHead = draw_box_wide(gDisplayListHead, x - (w / 2), y - (h / 2), (w / 2) + x, (h / 2) + y,
+                                                 color->red, color->green, color->blue,
+                                                 0xFF - (gCurrentTransitionTime[arg0] * 0xFF / gTransitionDuration[arg0]));
+            }
             break;
     }
 
@@ -5546,6 +5551,9 @@ void func_8009D77C(s32 arg0, s32 arg1, s32 arg2) {
                 gDisplayListHead = draw_box_wide_pause_background(gDisplayListHead, var_t3 - temp_v1, var_t4 - temp_t8,
                                                                   rightEdge + someMath0, someMath1, temp_v0_2->red,
                                                                   temp_v0_2->green, temp_v0_2->blue, var_t2);
+            } else if ((arg0 == 4)) {
+                gDisplayListHead = draw_box_wide(gDisplayListHead, var_t3 - temp_v1, var_t4 - temp_t8, someMath0, someMath1,
+                                                 temp_v0_2->red, temp_v0_2->green, temp_v0_2->blue, var_t2);
             }
             break;
     }
@@ -5624,6 +5632,9 @@ void func_8009D998(s32 arg0) {
                 gDisplayListHead =
                     draw_box_wide_pause_background(gDisplayListHead, var_t0 - temp_v0, var_t1 - temp_v1,
                                                    rightEdge + someMath0, someMath1, 0, 0, 0, 0x000000FF);
+            } else if ((arg0 == 1) || (arg0 == 3)) {
+                gDisplayListHead = draw_box_wide(gDisplayListHead, var_t0 - temp_v0, var_t1 - temp_v1, someMath0, someMath1,
+                                                 0, 0, 0, 0x000000FF);
             }
             break;
     }


### PR DESCRIPTION
Fixes #526 

The Lakitu screen fades are also used in the menu. This meant that when 3P or 4P menu options were selected, the related cases would be hit, which has been modified compared to decomp (I assume to better handle transitions when racing in wider formats).

Adding another `else if` which checks for `arg0 == 4` (which seems to be the menu) and drawing our original `draw_box_wide` seems to fix this issue.

Before:
![before](https://github.com/user-attachments/assets/be694b43-7146-4f50-a769-c34734e7374f)

After:
![after](https://github.com/user-attachments/assets/5290eb98-5d90-4e90-833a-2a07fd01c6fa)
