### PR TITLE
Fix compiling for linux arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,9 @@ else()
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG ${COMMON_CXX_FLAGS}")
 endif()
 
+# Toggle for GLES (Required for many ARM/Mobile platforms)
+option(USE_OPENGLES "Use OpenGLES instead of Desktop OpenGL" OFF)
+
 # Set game compilation version
 set(VERSION us)
 set(USE_NETWORKING OFF)
@@ -189,6 +192,7 @@ set(GFX_DEBUG_DISASSEMBLER OFF)
 # Add compile definitions for the target
 add_compile_definitions(
     VERSION_US=1
+    $<$<BOOL:${USE_OPENGLES}>:USE_OPENGLES>
     ENABLE_RUMBLE=1
     F3DEX_GBI=1
     _LANGUAGE_C
@@ -200,10 +204,6 @@ add_compile_definitions(
  SPAGHETTI_VERSION="${PROJECT_VERSION}"
 )
 
-# Find necessary libraries
-if (UNIX AND NOT APPLE)
-  find_package(OpenGL REQUIRED)
-endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
   configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/properties.h.in ${CMAKE_CURRENT_SOURCE_DIR}/properties.h @ONLY)
@@ -319,6 +319,18 @@ else()
   add_executable(${PROJECT_NAME} ${ALL_FILES})
 endif()
 
+################################################################################
+# OpenGL / OpenGLES library
+################################################################################
+if (UNIX AND NOT APPLE)
+    if (USE_OPENGLES)
+        find_library(GLESv2_LIBRARY GLESv2 REQUIRED)
+        target_link_libraries(${PROJECT_NAME} PRIVATE ${GLESv2_LIBRARY})
+    else()
+        find_package(OpenGL REQUIRED)
+        target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL::GL)
+    endif()
+endif()
 
 ################################################################################
 # MSVC runtime library
@@ -402,9 +414,12 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/libultraship/include
   ${CMAKE_CURRENT_SOURCE_DIR}/libultraship/include/libultraship
   ${SDL2_INCLUDE_DIRS}
-  ${GLEW_INCLUDE_DIRS}
   ${dr_libs_SOURCE_DIR}
 )
+
+if (NOT USE_OPENGLES)
+    include_directories(${GLEW_INCLUDE_DIRS})
+endif()
 
 add_subdirectory(libultraship ${CMAKE_CURRENT_SOURCE_DIR}/libultraship)
 add_dependencies(${PROJECT_NAME} libultraship)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,8 +516,10 @@ option(USE_STANDALONE "Build as a standalone executable" OFF)
 option(BUILD_STORMLIB "Build with StormLib support" OFF)
 
 option(BUILD_SM64 "Build with Super Mario 64 support" OFF)
+option(BUILD_MK64 "Build with Mario Kart 64 support" ON)
 option(BUILD_SF64 "Build with Star Fox 64 support" OFF)
 option(BUILD_FZERO "Build with F-Zero X support" OFF)
+option(BUILD_MARIO_ARTIST "Build with Mario Artist support" OFF)
 
 add_subdirectory(torch)
 target_link_libraries(${PROJECT_NAME} PRIVATE torch "${ADDITIONAL_LIBRARY_DEPENDENCIES}")

--- a/courses/harbour/ship2_model.c
+++ b/courses/harbour/ship2_model.c
@@ -1,5 +1,6 @@
 #include <libultraship.h>
 #include <libultra/gbi.h>
+#include <macros.h>
 
 Gfx ship2_flag_rgba16_aligner[] = {gsSPEndDisplayList()};
 u8 ship2_flag_rgba16[] = {
@@ -263,7 +264,7 @@ u8 ship2_flag_rgba16[] = {
 };
 
 Gfx ship2_window_i8_aligner[] = {gsSPEndDisplayList()};
-u8 ship2_window_i8[] = {
+ALIGNED8 u8 ship2_window_i8[] = {
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
 	

--- a/include/macros.h
+++ b/include/macros.h
@@ -75,6 +75,13 @@
 #define ALIGNED16
 #endif
 
+// Align to 4096-byte boundary for 64-bit page requirements
+#ifdef __GNUC__
+#define ALIGNED4096 __attribute__((aligned(4096)))
+#else
+#define ALIGNED4096
+#endif
+
 // Fixed point macros
 #define FTOFIX(f) ((s32) ((f) * 65536.0))
 #define ITOFIX(i) ((s32) ((i) << 16))

--- a/include/macros.h
+++ b/include/macros.h
@@ -70,7 +70,7 @@
 
 // Align to 16-byte boundary for audio lib requirements
 #ifdef __GNUC__
-#define ALIGNED16
+#define ALIGNED16 __attribute__((aligned(16)))
 #else
 #define ALIGNED16
 #endif

--- a/include/macros.h
+++ b/include/macros.h
@@ -63,7 +63,7 @@
 
 // Align to 8-byte boundary for DMA requirements
 #ifdef __GNUC__
-#define ALIGNED8
+#define ALIGNED8 __attribute__((aligned(8)))
 #else
 #define ALIGNED8
 #endif

--- a/include/stubs.h
+++ b/include/stubs.h
@@ -1,7 +1,6 @@
 #include <libultraship.h>
 
 #ifdef _WIN32
-#define bzero(b, len) (memset((b), '\0', (len)), (void) 0)
 #define bcopy(b1, b2, len) (memmove((b2), (b1), (len)), (void) 0)
 #endif
 

--- a/src/code_80005FD0.c
+++ b/src/code_80005FD0.c
@@ -3468,7 +3468,7 @@ void func_8000F124(void) {
 
 // Delete track waypoints
 void clear_path_point(TrackPathPoint* arg0, size_t size) {
-    bzero((void*) arg0, size * sizeof(TrackPathPoint));
+    memset((void*) arg0, 0, size * sizeof(TrackPathPoint));
 }
 
 // Appears to allocate memory for each track.

--- a/src/code_8006E9C0.c
+++ b/src/code_8006E9C0.c
@@ -60,7 +60,7 @@ void reset_object_variable(void) {
     s32 j;
     func_8006EB10();
     clear_object_list();
-    bzero(playerHUD, HUD_PLAYERS_SIZE * sizeof(hud_player));
+    memset(playerHUD, 0, HUD_PLAYERS_SIZE * sizeof(hud_player));
 
     for (i = 0; i < HUD_PLAYERS_SIZE; i++) {
         playerHUD[i].lapCount = 0;
@@ -114,7 +114,7 @@ void func_8006EB10(void) {
 }
 
 void clear_object_list() {
-    bzero(gObjectList, OBJECT_LIST_SIZE * sizeof(Object));
+    memset(gObjectList, 0, OBJECT_LIST_SIZE * sizeof(Object));
     objectListSize = -1;
 }
 

--- a/src/ending/podium_ceremony_actors.c
+++ b/src/ending/podium_ceremony_actors.c
@@ -105,7 +105,7 @@ CeremonyActor* find_available_entry(void) {
 
         // Find an inactive actor.
         if ((actor->isActive & 1) == 0) {
-            bzero(actor, sizeof(CeremonyActor));
+            memset(actor, 0, sizeof(CeremonyActor));
             actor->isActive = 1;
             actor->unk24 = 1.0f;
             return actor;
@@ -311,7 +311,7 @@ void unused_80280FA8(UNUSED CeremonyActor* actor) {
 void balloons_and_fireworks_init(void) {
     D_802874D8.actorTimer = 0;
     sPodiumActorList = (CeremonyActor*) get_next_available_memory_addr(sizeof(CeremonyActor) * 200);
-    bzero(sPodiumActorList, (sizeof(CeremonyActor) * 200));
+    memset(sPodiumActorList, 0, (sizeof(CeremonyActor) * 200));
     new_actor(&initDummy);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -522,7 +522,7 @@ void display_and_vsync(void) {
 
 void init_segment_ending_sequences(void) {
 #ifdef TARGET_N64
-    bzero((void*) SEG_ENDING, SEG_ENDING_SIZE);
+    memset((void*) SEG_ENDING, 0, SEG_ENDING_SIZE);
     osWritebackDCacheAll();
     dma_copy((u8*) SEG_ENDING, (u8*) SEG_ENDING_ROM_START, SEG_ENDING_ROM_SIZE);
     osInvalICache((void*) SEG_ENDING, SEG_ENDING_SIZE);
@@ -532,7 +532,7 @@ void init_segment_ending_sequences(void) {
 
 void init_segment_racing(void) {
 #ifdef TARGET_N64
-    bzero((void*) SEG_RACING, SEG_RACING_SIZE);
+    memset((void*) SEG_RACING, 0, SEG_RACING_SIZE);
     osWritebackDCacheAll();
     dma_copy((u8*) SEG_RACING, (u8*) SEG_RACING_ROM_START, SEG_RACING_ROM_SIZE);
     osInvalICache((void*) SEG_RACING, SEG_RACING_SIZE);

--- a/src/os/__osViInit.c
+++ b/src/os/__osViInit.c
@@ -15,7 +15,7 @@ extern OSViMode osViModeMpalLan1;
 extern OSViMode osViModeNtscLan1;
 
 void __osViInit(void) {
-    bzero(sViContexts, sizeof(sViContexts));
+    memset(sViContexts, 0, sizeof(sViContexts));
     __osViCurr = &sViContexts[0];
     __osViNext = &sViContexts[1];
     __osViNext->retraceCount = 1;

--- a/src/os/bstring.h
+++ b/src/os/bstring.h
@@ -28,7 +28,6 @@ extern "C" {
 
 extern void bcopy(const void*, void*, size_t);
 extern int bcmp(const void*, const void*, int);
-extern void bzero(void*, size_t);
 extern void blkclr(void*, int);
 
 #ifdef __cplusplus

--- a/src/os/osCartRomInit.c
+++ b/src/os/osCartRomInit.c
@@ -29,7 +29,7 @@ OSPiHandle* osCartRomInit(void) {
     CartRomHandle.domain = PI_DOMAIN1;
     // CartRomHandle.speed = 0;
 
-    bzero(&CartRomHandle.transferInfo, sizeof(__OSTranxInfo));
+    memset(&CartRomHandle.transferInfo, 0, sizeof(__OSTranxInfo));
 
     saveMask = __osDisableInt();
     CartRomHandle.next = __osPiTable;

--- a/src/os/osInitialize.c
+++ b/src/os/osInitialize.c
@@ -57,7 +57,7 @@ void osInitialize(void) {
     }
     osClockRate = osClockRate * 3 / 4;
     if (osResetType == RESET_TYPE_COLD_RESET) {
-        bzero(osAppNmiBuffer, sizeof(osAppNmiBuffer));
+        memset(osAppNmiBuffer, 0, sizeof(osAppNmiBuffer));
     }
 
     eu_sp30 = HW_REG(PI_STATUS_REG, u32);

--- a/src/os/osLeoDiskInit.c
+++ b/src/os/osLeoDiskInit.c
@@ -26,7 +26,7 @@ OSPiHandle* osLeoDiskInit(void) {
     HW_REG(PI_BSD_DOM2_PWD_REG, u32) = LeoDiskHandle.pulse;
     HW_REG(PI_BSD_DOM2_PGS_REG, u32) = LeoDiskHandle.pageSize;
     HW_REG(PI_BSD_DOM2_RLS_REG, u32) = LeoDiskHandle.relDuration;
-    bzero(&LeoDiskHandle.transferInfo, sizeof(__OSTranxInfo));
+    memset(&LeoDiskHandle.transferInfo, 0, sizeof(__OSTranxInfo));
     sp1c = __osDisableInt();
     LeoDiskHandle.next = __osPiTable;
     __osPiTable = &LeoDiskHandle;

--- a/src/port/audio/HMAS.h
+++ b/src/port/audio/HMAS.h
@@ -58,7 +58,7 @@ struct HMAS_Effect {
 struct HMAS_ChannelInfo {
     ma_sound* sound;
 
-    uint64_t cursor;
+    ma_uint64 cursor;
     float pitch;
     float volume;
 

--- a/src/racing/memory.c
+++ b/src/racing/memory.c
@@ -25,7 +25,7 @@
 s32 sGfxSeekPosition;
 s32 sPackedSeekPosition;
 
-static u8 sMemoryPool[0xFFFFFFF] ALIGNED16; // Stock memory pool size: 0xAB630
+static u8 sMemoryPool[0x10000000] ALIGNED4096;
 uintptr_t sPoolEnd = sMemoryPool + sizeof(sMemoryPool);
 
 uintptr_t sPoolFreeSpace;
@@ -88,17 +88,16 @@ static uintptr_t get_texture2(size_t offset, const course_texture* textures) {
  * Default memory size, 701.984 Kilobytes.
  */
 void initialize_memory_pool() {
+    // Clear pool
+    memset(sMemoryPool, 0, sizeof(sMemoryPool));
 
-    uintptr_t poolStart = sMemoryPool;
-    // uintptr_t sPoolEnd = sMemoryPool + sizeof(sMemoryPool);
+    // Force the pointer to be exactly at the start of the aligned array
+    uintptr_t poolStart = (uintptr_t)sMemoryPool;
+    
+    // Ensure sPoolEnd is exactly at the end of the 256MB block
+    sPoolEnd = poolStart + sizeof(sMemoryPool);
 
-    bzero(sMemoryPool, sizeof(sMemoryPool));
-
-    poolStart = ALIGN16(poolStart);
-    // Truncate to a 16-byte boundary.
-    sPoolEnd &= ~0xF;
-
-    gFreeMemorySize = (sPoolEnd - poolStart) - 0x10;
+    gFreeMemorySize = sPoolEnd - poolStart;
     gNextFreeMemoryAddress = poolStart;
 
     PRINT_MEMPOOL;
@@ -309,7 +308,7 @@ u8* load_lakitu_tlut_x64(const char** textureList, size_t length) {
     }
 
     u8* textures = (u8*) gNextFreeMemoryAddress;
-    gNextFreeMemoryAddress += size;
+    gNextFreeMemoryAddress = ALIGN16(gNextFreeMemoryAddress + size);
     size_t offset = 0;
     for (size_t i = 0; i < length; i++) {
         u8* tex = (u8*) LOAD_ASSET_RAW(textureList[i]);

--- a/src/racing/memory.c
+++ b/src/racing/memory.c
@@ -25,7 +25,7 @@
 s32 sGfxSeekPosition;
 s32 sPackedSeekPosition;
 
-static u8 sMemoryPool[0xFFFFFFF]; // Stock memory pool size: 0xAB630
+static u8 sMemoryPool[0xFFFFFFF] ALIGNED16; // Stock memory pool size: 0xAB630
 uintptr_t sPoolEnd = sMemoryPool + sizeof(sMemoryPool);
 
 uintptr_t sPoolFreeSpace;


### PR DESCRIPTION
This pull request contains several changes.

1. In HMAS.cpp a typedef mismatch causes linux arm64 builds to fail. It has been altered in HMAS.h to pass.
2. In CMakeLists.txt there was no definition to enable `BUILD_MK64` with the externally compiled torch, which would cause torch to throw an error on trying to make `mk64.o2r`. This definition has been added.
3. In macros.h `ALIGNED16` and `ALIGNED8` were empty. I added the alignment to the macros so they do something, and I added `ALIGNED4096` so the 256MB allocation is set at the start of the virtual memory page.
4. Added the `ALIGNED16` macro to the memory pool in memory.c
5. In CMakeLists.txt added `USE_OPENGLES` define
7. Changed to memset

An opt-in for segmented addresses is missing somewhere, see: https://github.com/Kenix3/libultraship/pull/1004