### PR TITLE
Fix Item Window

### DIFF
--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -2621,9 +2621,11 @@ void func_8004E6C4(s32 playerId) {
     object = &gObjectList[objectIndex];
     if (object->state >= 2) {
         temp_v0 = &playerHUD[playerId];
+        FrameInterpolation_RecordOpenChild("item_window_splitscreen", playerId);
         func_80047910(temp_v0->slideItemBoxX + temp_v0->itemBoxX, temp_v0->slideItemBoxY + temp_v0->itemBoxY, 0U,
-                      temp_v0->unknownScaling, (u8*) object->activeTLUT, (u8*) object->activeTexture, D_0D005C30,
+                      temp_v0->unknownScaling, (u8*) object->activeTLUT, (u8*) object->activeTexture, (Vtx*)LOAD_ASSET(D_0D005C30),
                       0x00000028, 0x00000020, 0x00000028, 0x00000020);
+        FrameInterpolation_RecordCloseChild();
     }
 }
 

--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -712,7 +712,7 @@ void draw_rectangle_texture_overlap(u8* tlut, u8* texture, Vtx* arg2, UNUSED s32
                                     s32 heighthalf) {
     s32 heightIndex;
     s32 vertexIndex = 0;
-    u8* img = (u8*) LOAD_ASSET(texture);
+    u8* img = texture;
 
     gDPLoadTLUT_pal256(gDisplayListHead++, tlut);
     for (heightIndex = 0; heightIndex < height / heighthalf; heightIndex++) {


### PR DESCRIPTION
The vertex is accessed via array. Needs to be loaded first.

The texture due to an lus update? Needs to not have load asset apparently.