### PR TITLE
Allowing user-set internal resolution in menu

### DIFF
--- a/src/port/ui/PortMenu.cpp
+++ b/src/port/ui/PortMenu.cpp
@@ -227,7 +227,6 @@ void PortMenu::AddSettings() {
     AddSidebarEntry("Settings", "Graphics", 3);
     AddWidget(path, "Renderer API (Needs reload)", WIDGET_VIDEO_BACKEND);
 
-#ifndef __APPLE__
     AddWidget(path, "Internal Resolution: %.0f%%", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar(CVAR_INTERNAL_RESOLUTION)
         .Callback([](WidgetInfo& info) {
@@ -252,7 +251,7 @@ void PortMenu::AddSettings() {
                 .Format("")
                 .Min(0.5f)
                 .Max(4.0f));
-#endif
+
 #ifndef __WIIU__
     AddWidget(path, "Anti-aliasing (MSAA): %d", WIDGET_CVAR_SLIDER_INT)
         .CVar(CVAR_MSAA_VALUE)


### PR DESCRIPTION
Is there a reason why the internal resolution slider is being prevented on MacOS?