### PR TITLE
Add CoreAudio to audio backend combobox map for macOS

### DIFF
--- a/src/port/ui/MenuTypes.h
+++ b/src/port/ui/MenuTypes.h
@@ -257,6 +257,7 @@ struct MainMenuEntry {
 static const std::unordered_map<Ship::AudioBackend, const char*> audioBackendsMap = {
     { Ship::AudioBackend::WASAPI, "Windows Audio Session API" },
     { Ship::AudioBackend::SDL, "SDL" },
+    { Ship::AudioBackend::COREAUDIO, "CoreAudio" },
 };
 
 static const std::unordered_map<Ship::WindowBackend, const char*> windowBackendsMap = {


### PR DESCRIPTION
macOS uses COREAUDIO as the default audio backend, but the combobox display map in MenuTypes.h only contained SDL and WASAPI. This causes an unordered_map::at crash on first frame draw when the Audio API dropdown tries to render.

Fixes the menu crash portion of [#681](https://github.com/HarbourMasters/SpaghettiKart/issues/681).