### PR TITLE
Force type correctness when calculating collision hashes

### DIFF
--- a/src/engine/editor/Collision.cpp
+++ b/src/engine/editor/Collision.cpp
@@ -37,7 +37,7 @@ namespace TrackEditor {
                     break;
                 case G_DL_OTR_HASH:
                     ptr++;
-                    GenerateCollisionMesh(object, (Gfx*)ResourceGetDataByCrc(((uint64_t)(ptr->words.w0 << 32)) + ptr->words.w1), scale);
+                    GenerateCollisionMesh(object, (Gfx*)ResourceGetDataByCrc(((uint64_t)(ptr->words.w0) << 32) + ptr->words.w1), scale);
                     break;
                 case G_DL_OTR_FILEPATH:
                    // printf("otr filepath: %s\n", (const char*)hi);
@@ -48,7 +48,7 @@ namespace TrackEditor {
                     break;
                 case G_VTX_OTR_HASH: {
                     ptr++;
-                    vtx = (Vtx*)ResourceGetDataByCrc(((uint64_t)(ptr->words.w0 << 32)) + ptr->words.w1);
+                    vtx = (Vtx*)ResourceGetDataByCrc(((uint64_t)(ptr->words.w0) << 32) + ptr->words.w1);
                     break;
                 }
                 case G_VTX_OTR_FILEPATH: {

--- a/src/racing/collision.c
+++ b/src/racing/collision.c
@@ -2193,7 +2193,7 @@ void find_vtx_and_set_colours(Gfx* displayList, s8 alpha, u8 red, u8 green, u8 b
             find_vtx_and_set_colours((Gfx*) hi, alpha, red, green, blue);
         } else if (opcode == (G_DL_OTR_HASH << 24)) {
             gfx++;
-            uint64_t hash = ((uint64-t)gfx->words.w0) << 32 | gfx->words.w1;
+            uint64_t hash = ((uint64_t)gfx->words.w0) << 32 | gfx->words.w1;
             find_vtx_and_set_colours(ResourceGetDataByCrc(hash), alpha, red, green, blue);
         } else if (opcode == (G_DL_OTR_FILEPATH << 24)) {
             find_vtx_and_set_colours(ResourceGetDataByName((const char*)hi), alpha, red, green, blue);

--- a/src/racing/collision.c
+++ b/src/racing/collision.c
@@ -2044,7 +2044,7 @@ void generate_collision_mesh(Gfx* addr, s8 surfaceType, u16 sectionId) {
                 break;
             case G_DL_OTR_HASH:
                 gfx++;
-                uint64_t hash = gfx->words.w0 << 32 | gfx->words.w1;
+                uint64_t hash = ((uint64_t)gfx->words.w0) << 32 | gfx->words.w1;
                 generate_collision_mesh(ResourceGetDataByCrc(hash), surfaceType, sectionId);
                 break;
             case G_DL_OTR_FILEPATH:
@@ -2073,7 +2073,7 @@ void generate_collision_mesh(Gfx* addr, s8 surfaceType, u16 sectionId) {
             }
             case G_VTX_OTR_HASH:
                 gfx++;
-                hash = gfx->words.w0 << 32 | gfx->words.w1;
+                hash = ((uint64_t)gfx->words.w0) << 32 | gfx->words.w1;
                 int numVerts = (lo >> 12) & ((1<<8)-1);
                 int bufferIndex = ((lo >> 1) & ((1<<7)-1));
                 bufferIndex = numVerts - bufferIndex; 
@@ -2193,7 +2193,7 @@ void find_vtx_and_set_colours(Gfx* displayList, s8 alpha, u8 red, u8 green, u8 b
             find_vtx_and_set_colours((Gfx*) hi, alpha, red, green, blue);
         } else if (opcode == (G_DL_OTR_HASH << 24)) {
             gfx++;
-            uint64_t hash = gfx->words.w0 << 32 | gfx->words.w1;
+            uint64_t hash = ((uint64-t)gfx->words.w0) << 32 | gfx->words.w1;
             find_vtx_and_set_colours(ResourceGetDataByCrc(hash), alpha, red, green, blue);
         } else if (opcode == (G_DL_OTR_FILEPATH << 24)) {
             find_vtx_and_set_colours(ResourceGetDataByName((const char*)hi), alpha, red, green, blue);
@@ -2216,7 +2216,7 @@ void find_vtx_and_set_colours(Gfx* displayList, s8 alpha, u8 red, u8 green, u8 b
             set_vertex_colours((uintptr_t)vtx, count, index, alpha, red, green, blue);
         } else if (opcode == (G_VTX_OTR_HASH << 24)) {
             gfx++;
-            uint64_t hash = gfx->words.w0 << 32 | gfx->words.w1;
+            uint64_t hash = ((uint64_t)gfx->words.w0) << 32 | gfx->words.w1;
             int numVerts = (lo >> 12) & ((1<<8)-1);
             int bufferIndex = ((lo >> 1) & ((1<<7)-1));
             bufferIndex = numVerts - bufferIndex; 


### PR DESCRIPTION
On gcc (especially for arm devices), the current way the hash  var is calculated will result in complete loss of w0 control word due to the fact the cast to uint64_t will be performed as last operation (aka as if the calculation was:
`uint64_t hash = (uint64_t)(gfx->words.w0 << 32 | gfx->words.w1);`

This results in the 32 bit left shift to effectively turn the first param as a full 0x00000000 or'ed against w1.