### PR TITLE
Fix missing texture size initialization for clouds.

### DIFF
--- a/src/engine/sky/SkyCloud.cpp
+++ b/src/engine/sky/SkyCloud.cpp
@@ -27,6 +27,8 @@ SkyCloud::SkyCloud(ScreenContext* screen, u16 cloudVariant, u16 posY, u16 rotY, 
     mY = posY;
     mRotY = rotY;
     mScale = (f32) scalePercent / 100.0;
+    mTextureWidth = 64;
+    mTextureHeight = 32;
 
     // Stock
     if (GameEngine_ResourceGetTexTypeByName((const char*)CM_GetProps()->CloudTexture) != 1) {


### PR DESCRIPTION
This was breaking clouds rendering (at least on Vita).