### PR TITLE
Fix Switch build

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -84,7 +84,6 @@ GameEngine::GameEngine() {
 
 #ifdef __SWITCH__
     Ship::Switch::Init(Ship::PreInitPhase);
-    Ship::Switch::Init(Ship::PostInitPhase);
 #endif
 
 #ifdef _WIN32

--- a/src/port/ui/PortMenu.cpp
+++ b/src/port/ui/PortMenu.cpp
@@ -97,11 +97,13 @@ void PortMenu::AddSettings() {
     WidgetPath path = { "Settings", "General", SECTION_COLUMN_1 };
 
     static bool isFullscreen = false;
+#ifndef __SWITCH__
     AddWidget(path, "Toggle Fullscreen", WIDGET_CHECKBOX)
         .ValuePointer(&isFullscreen)
         .PreFunc([](WidgetInfo& info) { isFullscreen = Ship::Context::GetInstance()->GetWindow()->IsFullscreen(); })
         .Callback([](WidgetInfo& info) { Ship::Context::GetInstance()->GetWindow()->ToggleFullscreen(); })
         .Options(CheckboxOptions().Tooltip("Toggles Fullscreen On/Off."));
+#endif
 
     AddWidget(path, "Startup Behaviour", WIDGET_CVAR_COMBOBOX)
         .CVar("gSkipIntro")
@@ -170,12 +172,14 @@ void PortMenu::AddSettings() {
         .CVar("gEnhancements.Mods.AlternateAssetsHotkey")
         .Options(
             CheckboxOptions().Tooltip("Allows pressing the Tab key to toggle alternate assets").DefaultValue(true));
+#ifndef __SWITCH__
     AddWidget(path, "Open App Files Folder", WIDGET_BUTTON)
         .Callback([](WidgetInfo& info) {
             std::string filesPath = Ship::Context::GetInstance()->GetAppDirectoryPath();
             SDL_OpenURL(std::string("file:///" + std::filesystem::absolute(filesPath).string()).c_str());
         })
         .Options(ButtonOptions().Tooltip("Opens the folder that contains the save and mods folders, etc."));
+#endif
 
     // Audio Settings
     path.sidebarName = "Audio";


### PR DESCRIPTION
Fixes the blackscreen on boot and removes some useless UI options on Switch.

Precompiled build: [spaghetti-switch-1.0.0-build.zip](https://github.com/user-attachments/files/28807714/spaghetti-switch-1.0.0-build.zip)
