### PR TITLE
Fix stale macOS Info.plist version (0.1.0 → 1.0.0)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleExecutable</key>
     <string>SpaghettiKart</string>
     <key>CFBundleGetInfoString</key>
-    <string>0.1.0</string>
+    <string>1.0.0</string>
     <key>CFBundleIconFile</key>
     <string>SpaghettiKart.icns</string>
     <key>CFBundleIdentifier</key>
@@ -22,11 +22,11 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>1.0.0</string>
     <key>CFBundleSignature</key>
     <string>ZMM</string>
     <key>CFBundleVersion</key>
-    <string>0.1.0</string>
+    <string>1.0.0</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 2024 HarbourMasters.</string>
     <key>LSApplicationCategoryType</key>


### PR DESCRIPTION
The macOS bundle version strings in `Info.plist` are stuck at `0.1.0`, while the project is at `1.0.0` (`project(Spaghettify VERSION 1.0.0)`). As a result the built `.app` (and the cpack Bundle) reports `0.1.0` in Finder → Get Info and in `CFBundleShortVersionString` / `CFBundleVersion`.

This bumps the three version strings (`CFBundleGetInfoString`, `CFBundleShortVersionString`, `CFBundleVersion`) to `1.0.0` to match the project version. No other changes.
