### PR TITLE
Fix crash when declining the first-run ROM-extraction prompt

### DIFF
--- a/src/engine/mods/ModManager.cpp
+++ b/src/engine/mods/ModManager.cpp
@@ -5,6 +5,7 @@
 #include "port/Engine.h"
 #include "semver.hpp"
 #include "utils/StringHelper.h"
+#include <cstdlib>
 #include <memory>
 #include <optional>
 #include <string>
@@ -51,14 +52,19 @@ void UnloadMods() {
     Mods.clear();
 }
 
+// These bail-outs all run during InitModsSystem(), i.e. before the game world is set up.
+// Use _Exit instead of exit so the global `static World sWorldInstance` destructor does not
+// run: its CleanWorld() dereferences Sky::Instance and other singletons that are still null
+// at this point, which segfaults — a crash report on what should be a clean quit (e.g. when
+// the user declines the first-run "Generate one now?" prompt).
 void GenerateAssetsMods() {
     if (GameEngine::ShowYesNoBox("No O2R Files", "No O2R files found. Generate one now?") == IDYES) {
         if (!GameEngine::GenAssetFile()) {
             GameEngine::ShowMessage("Error", "An error occured, no O2R file was generated.\n\nExiting...");
-            exit(1);
+            _Exit(1);
         }
     } else {
-        exit(1);
+        _Exit(1);
     }
 }
 
@@ -241,7 +247,7 @@ void FindAndLoadMods() {
                                     " is missing a mods.toml file. The Mod are likely incompatible.\n\n"
                                     "Do you want to continue loading the mods?";
             if (GameEngine::ShowYesNoBox("Missing mods.toml", msg.c_str()) == IDNO) {
-                exit(1);
+                _Exit(1);
             }
             metadata.name = std::filesystem::path(path).stem().string();
             semver::parse("0.0.0", metadata.version);
@@ -260,7 +266,7 @@ void DetectCyclicDependencies() {
         }
         msg += "\nPlease resolve these cyclic dependencies before continuing.\n";
         GameEngine::ShowMessage("Cyclic Dependency Issues", msg.c_str());
-        exit(1);
+        _Exit(1);
     }
 }
 
@@ -281,7 +287,7 @@ void DetectOutdatedDependencies() {
     if (exitDueToErrors) {
         allDepIssues += "\nPlease resolve these dependency issues before continuing.\n";
         GameEngine::ShowMessage("Dependency Issues", allDepIssues.c_str());
-        exit(1);
+        _Exit(1);
     }
 }
 

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -1,5 +1,6 @@
 #include "Engine.h"
 
+#include <cstdlib>
 #include "ship/utils/StringHelper.h"
 #include "GameExtractor.h"
 #include "mods/ModManager.h"
@@ -269,14 +270,16 @@ bool GameEngine::GenAssetFile() {
 
     if (!extractor->SelectGameFromUI()) {
         ShowMessage("Error", "No ROM selected.\n\nExiting...");
-        exit(1);
+        // _Exit, not exit: this runs before the game world is initialized, so running the
+        // global World destructor (CleanWorld) would dereference still-null singletons and crash.
+        _Exit(1);
     }
 
     auto game = extractor->ValidateChecksum();
     if (!game.has_value()) {
         ShowMessage("Unsupported ROM",
                     "The provided ROM is not supported.\n\nCheck the readme for a list of supported versions.");
-        exit(1);
+        _Exit(1);
     }
 
     ShowMessage(("Found " + game.value()).c_str(),


### PR DESCRIPTION
### Problem
Declining the first-run **"No O2R files found. Generate one now?"** prompt pops a crash report instead of quitting cleanly. The crash is a `SIGSEGV` in the global `static World` destructor:

```
World::CleanWorld()        <- dereferences Sky::Instance (null)
exit
InitModsSystem()
```

### Cause
`InitModsSystem()` runs **before** the game world is initialized. Its bail-out paths call `exit()`, which then runs `atexit`/static destructors — including the global `static World sWorldInstance`. `~World()` → `CleanWorld()` dereferences `Sky::Instance` and other singletons that are still null this early in startup, so it segfaults. The user just wanted to quit, but gets a crash dialog.

This affects every pre-init bail-out in `InitModsSystem()`:
- declining O2R generation, and a failed generation (`GenerateAssetsMods`)
- a mod missing `mods.toml`
- cyclic / outdated mod dependencies
- `GenAssetFile()`'s "No ROM selected" and "Unsupported ROM" cases

### Fix
Use `_Exit(1)` instead of `exit(1)` on these pre-initialization bail-outs, so no static destructors run. Surfaced on macOS but the cause is platform-independent.

Two files, +`#include <cstdlib>`, `exit(1)` → `_Exit(1)` on the bail paths. No behavior change other than not crashing on the way out.
