### PR TITLE
Fix widescreen letterbox/divider left-edge clipping on ARM64

### DIFF
--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -3476,8 +3476,14 @@ Gfx* draw_box_fill_wide(Gfx* displayListHead, s32 ulx, s32 uly, s32 lrx, s32 lry
     gSPDisplayList(displayListHead++, D_02008030);
     gDPSetFillColor(displayListHead++, (GPACK_RGBA5551(red, green, (u32) blue, alpha) << 0x10 |
                                         GPACK_RGBA5551(red, green, (u32) blue, alpha)));
-    gDPFillWideRectangle(displayListHead++, OTRGetDimensionFromLeftEdge(ulx) - 1, uly, OTRGetDimensionFromRightEdge(lrx) + 1,
-                         lry);
+    // Use the integer Rect getters here: feeding the float getters' negative
+    // left-edge result into _SHIFTL casts float->unsigned, which is UB — x86
+    // wraps (and the wide-rect handler sign-extends it back), but ARM64
+    // saturates negatives to 0, so on Apple Silicon the fill started at the
+    // 4:3 left edge instead of the true left edge (visible as a sky notch
+    // left of the race-intro letterbox bars in widescreen).
+    gDPFillWideRectangle(displayListHead++, OTRGetRectDimensionFromLeftEdge(ulx) - 1, uly,
+                         OTRGetRectDimensionFromRightEdge(lrx) + 1, lry);
     gDPFillRectangle(displayListHead++, ulx, uly, lrx, lry);
     gSPDisplayList(displayListHead++, D_02008058);
     return displayListHead;

--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -3476,12 +3476,9 @@ Gfx* draw_box_fill_wide(Gfx* displayListHead, s32 ulx, s32 uly, s32 lrx, s32 lry
     gSPDisplayList(displayListHead++, D_02008030);
     gDPSetFillColor(displayListHead++, (GPACK_RGBA5551(red, green, (u32) blue, alpha) << 0x10 |
                                         GPACK_RGBA5551(red, green, (u32) blue, alpha)));
-    // Use the integer Rect getters here: feeding the float getters' negative
-    // left-edge result into _SHIFTL casts float->unsigned, which is UB — x86
-    // wraps (and the wide-rect handler sign-extends it back), but ARM64
-    // saturates negatives to 0, so on Apple Silicon the fill started at the
-    // 4:3 left edge instead of the true left edge (visible as a sky notch
-    // left of the race-intro letterbox bars in widescreen).
+    // Use the integer Rect getters: the float getters' negative left edge goes
+    // through a float->unsigned cast in _SHIFTL (UB) that ARM64 saturates to 0,
+    // pushing the fill's left edge to the 4:3 boundary in widescreen.
     gDPFillWideRectangle(displayListHead++, OTRGetRectDimensionFromLeftEdge(ulx) - 1, uly,
                          OTRGetRectDimensionFromRightEdge(lrx) + 1, lry);
     gDPFillRectangle(displayListHead++, ulx, uly, lrx, lry);

--- a/src/racing/skybox_and_splitscreen.c
+++ b/src/racing/skybox_and_splitscreen.c
@@ -308,11 +308,16 @@ void func_802A4300(void) {
             gDPFillRectangle(gDisplayListHead++, 157, 0, 159, 239);
             break;
         case SCREEN_MODE_2P_SPLITSCREEN_HORIZONTAL:
-            gDPFillWideRectangle(gDisplayListHead++, OTRGetDimensionFromLeftEdge(0), 119, OTRGetGameRenderWidth(), 121);
+            // Integer Rect getter: the float getter's negative result through
+            // _SHIFTL is float->unsigned UB, which saturates to 0 on ARM64 and
+            // clips the divider's left extension (see draw_box_fill_wide).
+            gDPFillWideRectangle(gDisplayListHead++, OTRGetRectDimensionFromLeftEdge(0), 119,
+                                 OTRGetGameRenderWidth(), 121);
             break;
         case SCREEN_MODE_3P_4P_SPLITSCREEN:
             gDPFillRectangle(gDisplayListHead++, 157, 0, 159, 239);
-            gDPFillWideRectangle(gDisplayListHead++, OTRGetDimensionFromLeftEdge(0), 119, OTRGetGameRenderWidth(), 121);
+            gDPFillWideRectangle(gDisplayListHead++, OTRGetRectDimensionFromLeftEdge(0), 119,
+                                 OTRGetGameRenderWidth(), 121);
             break;
     }
     gDPPipeSync(gDisplayListHead++);


### PR DESCRIPTION
## Problem

In widescreen, the race-intro letterbox bars (and the 2P/4P splitscreen dividers) start at the 4:3 edge instead of extending to the left edge of the window — a black notch is missing on the left side. Windows/x86 builds don't show this, macOS ARM64 does.

| | |
|---|---|
| Cause | `draw_box_fill_wide` / `func_802A4300` pass the **float** `OTRGetDimensionFromLeftEdge` result (negative in widescreen) into `_SHIFTL`, which casts to unsigned. Float→unsigned of a negative value is UB: x86's conversion wraps and the sign is recovered downstream (so the bug is invisible there), but ARM64's `fcvtzu` **saturates to 0**, so the rectangle starts at x=0 of the 4:3 area. |
| Fix | Use the integer `OTRGetRectDimensionFrom*Edge` getters, which is what the wide-rect macros expect. |

Verified on macOS (Apple Silicon): wide fills now span the full window (e.g. −34…353 in 320-space at 16:9), matching x86 behavior; splitscreen dividers likewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)