### PR TITLE
Fix macOS arm64 build: fmt consteval error in the TorchExternal sub-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,19 @@ cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
 project(Spaghettify VERSION 1.0.0 LANGUAGES C CXX ASM)
 include(FetchContent)
 
+# fmt's consteval format-string checking fails to compile under newer
+# AppleClang (Xcode 16+) with the spdlog/fmt versions in use (both vcpkg's on
+# CI and Torch's bundled copy — see cmake/TorchExternalFixes.cmake for the
+# latter):
+#   error: call to consteval function 'fmt::basic_format_string<...>' is not
+#   a constant expression
+# Defining FMT_CONSTEVAL as empty falls back to fmt's pre-C++20 constexpr
+# checking, which compiles cleanly with identical runtime behavior. Scoped to
+# AppleClang; other platforms and compilers are untouched.
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_definitions("FMT_CONSTEVAL=")
+endif()
+
 set(NATO_PHONETIC_ALPHABET
   "Alfa" "Bravo" "Charlie" "Delta" "Echo" "Foxtrot" "Golf" "Hotel"
   "India" "Juliett" "Kilo" "Lima" "Mike" "November" "Oscar" "Papa"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,10 +704,18 @@ add_custom_command(
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
   include(ExternalProject)
+  # Torch's pinned spdlog bundles an fmt that trips a consteval error under
+  # newer AppleClang (Xcode 16+): "call to consteval function
+  # 'fmt::basic_format_string<...>' is not a constant expression". Neutralize
+  # FMT_CONSTEVAL inside the Torch sub-build via CMAKE_PROJECT_INCLUDE (Torch's
+  # CMakeLists overwrites CMAKE_CXX_FLAGS, so flags can't be injected that
+  # way). Fixes the build-macos-arm64 job; the intel runner's older Xcode
+  # doesn't hit it.
   ExternalProject_Add(TorchExternal
     PREFIX TorchExternal
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/torch
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/torch
+               -DCMAKE_PROJECT_INCLUDE=${CMAKE_SOURCE_DIR}/cmake/TorchExternalFixes.cmake
 )
 
   ExternalProject_Get_Property(TorchExternal install_dir)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ include(FetchContent)
 # Defining FMT_CONSTEVAL as empty falls back to fmt's pre-C++20 constexpr
 # checking, which compiles cleanly with identical runtime behavior. Scoped to
 # AppleClang; other platforms and compilers are untouched.
+# TODO: Temporary hack. Remove this (plus cmake/TorchExternalFixes.cmake and
+# the vcpkg.json fmt/spdlog pins) once the Torch pin is bumped past Torch's
+# spdlog/fmt update. Note the bump also needs matching MK64 loader changes,
+# see the discussion on PR #712.
 if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_definitions("FMT_CONSTEVAL=")
 endif()
@@ -724,6 +728,9 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "NintendoSwitch")
   # CMakeLists overwrites CMAKE_CXX_FLAGS, so flags can't be injected that
   # way). Fixes the build-macos-arm64 job; the intel runner's older Xcode
   # doesn't hit it.
+  # TODO: Temporary hack. Remove the CMAKE_PROJECT_INCLUDE line below (plus
+  # cmake/TorchExternalFixes.cmake itself) once the Torch pin is bumped past
+  # Torch's spdlog/fmt update, see the discussion on PR #712.
   ExternalProject_Add(TorchExternal
     PREFIX TorchExternal
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/torch

--- a/cmake/TorchExternalFixes.cmake
+++ b/cmake/TorchExternalFixes.cmake
@@ -1,0 +1,14 @@
+# Included in the TorchExternal sub-build via CMAKE_PROJECT_INCLUDE (runs right
+# after Torch's project() call).
+#
+# Torch's pinned spdlog bundles an fmt whose consteval format-string checking
+# fails to compile under newer AppleClang (Xcode 16+):
+#   error: call to consteval function 'fmt::basic_format_string<...>' is not a
+#   constant expression
+# Defining FMT_CONSTEVAL to empty falls back to fmt's pre-C++20 constexpr
+# checking, which compiles cleanly. Scoped to AppleClang so other platforms and
+# compilers are untouched. add_compile_definitions (rather than CMAKE_CXX_FLAGS)
+# because Torch's CMakeLists overwrites the latter.
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_definitions("FMT_CONSTEVAL=")
+endif()

--- a/cmake/TorchExternalFixes.cmake
+++ b/cmake/TorchExternalFixes.cmake
@@ -9,6 +9,10 @@
 # checking, which compiles cleanly. Scoped to AppleClang so other platforms and
 # compilers are untouched. add_compile_definitions (rather than CMAKE_CXX_FLAGS)
 # because Torch's CMakeLists overwrites the latter.
+# TODO: Temporary hack. Delete this file (plus the CMAKE_PROJECT_INCLUDE line
+# in CMakeLists.txt and the vcpkg.json fmt/spdlog pins) once the Torch pin is
+# bumped past Torch's spdlog/fmt update. Note the bump also needs matching
+# MK64 loader changes, see the discussion on PR #712.
 if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_definitions("FMT_CONSTEVAL=")
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -31,5 +31,17 @@
     "libogg",
     "libvorbis"
   ],
+  "overrides": [
+    {
+      "$reason": "fmt 11.0.2 (spdlog's dependency) fails to compile under newer AppleClang (consteval format-string checking) and hard-defines FMT_CONSTEVAL with no override guard, so it cannot be disabled either. 10.2.1 keeps the #ifndef guard, letting the AppleClang-scoped FMT_CONSTEVAL= define in CMakeLists.txt take effect. spdlog is pinned to the matching 1.14.1 (1.15.x requires fmt >= 11).",
+      "name": "fmt",
+      "version": "10.2.1",
+      "port-version": 2
+    },
+    {
+      "name": "spdlog",
+      "version": "1.14.1"
+    }
+  ],
   "builtin-baseline": "2e58bb35ff7a3a037920d959ce20cb4d8c22319a"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -33,7 +33,7 @@
   ],
   "overrides": [
     {
-      "$reason": "fmt 11.0.2 (spdlog's dependency) fails to compile under newer AppleClang (consteval format-string checking) and hard-defines FMT_CONSTEVAL with no override guard, so it cannot be disabled either. 10.2.1 keeps the #ifndef guard, letting the AppleClang-scoped FMT_CONSTEVAL= define in CMakeLists.txt take effect. spdlog is pinned to the matching 1.14.1 (1.15.x requires fmt >= 11).",
+      "$reason": "fmt 11.0.2 (spdlog's dependency) fails to compile under newer AppleClang (consteval format-string checking) and hard-defines FMT_CONSTEVAL with no override guard, so it cannot be disabled either. 10.2.1 keeps the #ifndef guard, letting the AppleClang-scoped FMT_CONSTEVAL= define in CMakeLists.txt take effect. spdlog is pinned to the matching 1.14.1 (1.15.x requires fmt >= 11). TODO: Temporary hack. Remove both pins (plus the FMT_CONSTEVAL blocks in CMakeLists.txt and cmake/TorchExternalFixes.cmake) once the Torch pin is bumped past Torch's spdlog/fmt update. Note the bump also needs matching MK64 loader changes, see the discussion on PR #712.",
       "name": "fmt",
       "version": "10.2.1",
       "port-version": 2


### PR DESCRIPTION
Follow-up to the conversations in #709 and #707 — this fixes the `build-macos-arm64` job that's currently failing on `main` (the same pre-existing macOS failures noted in #707's checks).

## Problem

The macOS arm64 runners (Xcode 16+/26) hit fmt's consteval format-string checking error in **three layers**, each masked by the previous one:

```
error: call to consteval function 'fmt::basic_format_string<...>' is not a constant expression
```

1. **Torch's bundled spdlog/fmt** (the TorchExternal sub-build) fails first, stopping every macOS build early.
2. With that fixed, the **game build** fails the same way via the vcpkg-provided spdlog/fmt headers.
3. The obvious compile-time opt-out doesn't work for layer 2: **vcpkg's fmt 11.0.2 removed the `#ifndef FMT_CONSTEVAL` guard** (and `FMT_USE_CONSTEVAL` is likewise unguarded in that version), so a `-DFMT_CONSTEVAL=` on the command line lands and is silently clobbered by fmt's own definition. The pinned vcpkg baseline has no newer fmt to move up to.

The `build-macos-intel` job still passes only because its runner image carries an older Xcode — it will hit the same wall when that image updates.

## Fix (one commit per layer)

- **Torch sub-build**: neutralize `FMT_CONSTEVAL` via `CMAKE_PROJECT_INCLUDE` (`cmake/TorchExternalFixes.cmake`) — Torch's CMakeLists overwrites `CMAKE_CXX_FLAGS`, so plain flag injection through `CMAKE_ARGS` is discarded. Scoped to AppleClang.
- **Game build**: the same AppleClang-scoped define at the project level.
- **vcpkg manifest**: pin fmt to **10.2.1** (the newest version in the baseline that keeps the `#ifndef` guard, making the define above effective) and spdlog to the matching **1.14.1** (1.15.x requires fmt ≥ 11 headers). ⚠️ Note this pin applies to the Windows legs too since it's the shared manifest — fmt 10.2.1 + spdlog 1.14.1 are a mature, widely-used pairing, and CI here will confirm, but happy to scope it differently if you'd prefer.

## Verification

Reproduced the CI environment locally on an Apple Silicon Mac with current Xcode: vcpkg checked out at the manifest's exact baseline (`2e58bb35ff`), configured with the vcpkg toolchain file and Ninja like the workflow does. The original failure reproduces without these changes; with them, TorchExternal and the full game build cleanly, and the resulting binary boots and runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)