### PR TITLE
macOS: disable the press-and-hold accent popup while holding movement keys

### DIFF
--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -943,6 +943,10 @@ void CM_ThrowRuntimeError(const char* fmt, ...) {
     exit(EXIT_FAILURE);
 }
 
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 #ifdef _WIN32
 int SDL_main(int argc, char** argv) {
 #else
@@ -955,6 +959,14 @@ extern "C"
 #ifdef _WIN32
     // Allow non-ascii characters for Windows
     setlocale(LC_ALL, ".UTF8");
+#endif
+#if defined(__APPLE__)
+    // Disable the macOS "press and hold" accent/diacritic popup for this app. SDL keeps a Cocoa text
+    // input context active, so holding a movement key is interpreted as holding a letter key in a text
+    // field, and macOS shows the accent picker instead of repeating it. Per-app equivalent of
+    // `defaults write -app <App> ApplePressAndHoldEnabled -bool false`; key repeat still works.
+    CFPreferencesSetAppValue(CFSTR("ApplePressAndHoldEnabled"), kCFBooleanFalse, kCFPreferencesCurrentApplication);
+    CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication);
 #endif
     // load_wasm();
     GameEngine::Create();


### PR DESCRIPTION
On macOS, holding a keyboard movement key (W/A/S/D, etc.) pops up the system accent/diacritic picker instead of repeating: SDL keeps a Cocoa text-input context active, so macOS treats the held game key as a held letter key in a text field.

Fix: disable the per-app `ApplePressAndHoldEnabled` default at `main()` start (the programmatic equivalent of `defaults write -app <App> ApplePressAndHoldEnabled -bool false`). Key repeat still works, nothing outside this app is affected, and non-Apple platforms are untouched (`__APPLE__`-guarded).

Verified on Apple Silicon: holding movement keys no longer opens the accent picker, in menus and in-game. (Note: macOS CI needs #712 to build at all; this change itself is platform-guarded and inert elsewhere.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)