### PR TITLE
Fix warnings regarding ambigious typings

### DIFF
--- a/include/actor_types.h
+++ b/include/actor_types.h
@@ -132,7 +132,7 @@ struct Actor {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -157,7 +157,7 @@ struct TrainCar {
     /* 0x10 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -179,7 +179,7 @@ struct RailroadCrossing {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -197,7 +197,7 @@ struct FallingRock {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -242,7 +242,7 @@ struct YoshiValleyEgg {
     // Note, pathCenter[1] should be understood to be the Y velocity of the egg
     // pathCenter[0] and pathCenter[2] are the X,Z coordinates of the center of the path
     /* 0x24 */ Vec3f pathCenter;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -261,7 +261,7 @@ struct KiwanoFruit {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -276,7 +276,7 @@ struct PaddleWheelBoat {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -289,7 +289,7 @@ struct PiranhaPlant {
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec4s timers; // A per-camera timer. Might be more appropriate to call this state
     /* 0x2C */ f32 unk_02C;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -304,7 +304,7 @@ struct PalmTree {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -321,7 +321,7 @@ typedef struct {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f unk_18;
     /* 0x24 */ Vec3f shellIndices; // Indices in gActorList for the shells "owned" by this parent
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 } TripleShellParent; // size = 0x70
 
@@ -349,7 +349,7 @@ struct ShellActor {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity; // All 0 until the shell is fired
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -368,7 +368,7 @@ struct ItemBox {
     /* 0x24 */ f32 origY; // Original Y position. Basically the Y position the box will reset to after being touched
     /* 0x28 */ f32 unk_028;
     /* 0x2C */ f32 unk_02C;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -385,7 +385,7 @@ struct FakeItemBox {
     /* 0x24 */ f32 playerId;
     /* 0x28 */ f32 targetY;
     /* 0x2C */ f32 unk_02C;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -401,7 +401,7 @@ struct BananaBunchParent {
     /* 0x1C */ s16 bananasAvailable;
     /* 0x1E */ s16 unk_1E;
     /* 0x20 */ f32 unk_20[4];
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 
@@ -424,7 +424,7 @@ struct BananaActor {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ Collision unk30;
+    /* 0x30 */ CollisionData unk30;
                const char* model;
 }; // size = 0x70
 

--- a/include/actor_types.h
+++ b/include/actor_types.h
@@ -132,7 +132,7 @@ struct Actor {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -157,7 +157,7 @@ struct TrainCar {
     /* 0x10 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -179,7 +179,7 @@ struct RailroadCrossing {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -197,7 +197,7 @@ struct FallingRock {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -242,7 +242,7 @@ struct YoshiValleyEgg {
     // Note, pathCenter[1] should be understood to be the Y velocity of the egg
     // pathCenter[0] and pathCenter[2] are the X,Z coordinates of the center of the path
     /* 0x24 */ Vec3f pathCenter;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -261,7 +261,7 @@ struct KiwanoFruit {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -276,7 +276,7 @@ struct PaddleWheelBoat {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -289,7 +289,7 @@ struct PiranhaPlant {
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec4s timers; // A per-camera timer. Might be more appropriate to call this state
     /* 0x2C */ f32 unk_02C;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -304,7 +304,7 @@ struct PalmTree {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -321,7 +321,7 @@ typedef struct {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f unk_18;
     /* 0x24 */ Vec3f shellIndices; // Indices in gActorList for the shells "owned" by this parent
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 } TripleShellParent; // size = 0x70
 
@@ -349,7 +349,7 @@ struct ShellActor {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity; // All 0 until the shell is fired
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -368,7 +368,7 @@ struct ItemBox {
     /* 0x24 */ f32 origY; // Original Y position. Basically the Y position the box will reset to after being touched
     /* 0x28 */ f32 unk_028;
     /* 0x2C */ f32 unk_02C;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -385,7 +385,7 @@ struct FakeItemBox {
     /* 0x24 */ f32 playerId;
     /* 0x28 */ f32 targetY;
     /* 0x2C */ f32 unk_02C;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -401,7 +401,7 @@ struct BananaBunchParent {
     /* 0x1C */ s16 bananasAvailable;
     /* 0x1E */ s16 unk_1E;
     /* 0x20 */ f32 unk_20[4];
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 
@@ -424,7 +424,7 @@ struct BananaActor {
     /* 0x16 */ s16 unk_16;
     /* 0x18 */ Vec3f pos;
     /* 0x24 */ Vec3f velocity;
-    /* 0x30 */ CollisionData unk30;
+    /* 0x30 */ struct Collision unk30;
                const char* model;
 }; // size = 0x70
 

--- a/include/bomb_kart.h
+++ b/include/bomb_kart.h
@@ -56,6 +56,6 @@ typedef struct {
 extern s32 gIndexObjectBombKart[NUM_BOMB_KARTS_MAX];
 
 extern BombKart gBombKarts[NUM_BOMB_KARTS_MAX];
-extern Collision gBombKartCollision[NUM_BOMB_KARTS_MAX];
+extern CollisionData gBombKartCollision[NUM_BOMB_KARTS_MAX];
 
 #endif

--- a/include/bomb_kart.h
+++ b/include/bomb_kart.h
@@ -56,6 +56,6 @@ typedef struct {
 extern s32 gIndexObjectBombKart[NUM_BOMB_KARTS_MAX];
 
 extern BombKart gBombKarts[NUM_BOMB_KARTS_MAX];
-extern CollisionData gBombKartCollision[NUM_BOMB_KARTS_MAX];
+extern struct Collision gBombKartCollision[NUM_BOMB_KARTS_MAX];
 
 #endif

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -144,7 +144,7 @@ typedef struct {
 } StaffGhost;
 // 80160ADC Banana's remaining
 
-typedef struct {
+typedef struct{
     /* 0x00 */ u16 unk30;
     /* 0x02 */ u16 unk32;
     /* 0x04 */ u16 unk34;
@@ -157,7 +157,7 @@ typedef struct {
     /* 0x24 */ Vec3f unk54;
     /* 0x30 */ Vec3f orientationVector;
     /* 0x3C */ f32 unk6C;
-} Collision;
+} CollisionData;
 
 typedef struct {
     /* 0x00 */ Vec3f pos;
@@ -336,7 +336,7 @@ typedef struct {
     /* 0x0108 */ f32 hopVerticalOffset;
     /* 0x010C */ s16 unk_10C;
     /* 0x010E */ char unk_10E[0x2];
-    /* 0x0110 */ Collision collision;
+    /* 0x0110 */ CollisionData collision;
     /* 0x0150 */ Mat3 unk_150;
     /* 0x0174 */ Mat3 orientationMatrix;
     /* 0x0198 */ KartTyre tyres[4];

--- a/include/common_structs.h
+++ b/include/common_structs.h
@@ -144,7 +144,7 @@ typedef struct {
 } StaffGhost;
 // 80160ADC Banana's remaining
 
-typedef struct{
+struct Collision{
     /* 0x00 */ u16 unk30;
     /* 0x02 */ u16 unk32;
     /* 0x04 */ u16 unk34;
@@ -157,7 +157,7 @@ typedef struct{
     /* 0x24 */ Vec3f unk54;
     /* 0x30 */ Vec3f orientationVector;
     /* 0x3C */ f32 unk6C;
-} CollisionData;
+};
 
 typedef struct {
     /* 0x00 */ Vec3f pos;
@@ -336,7 +336,7 @@ typedef struct {
     /* 0x0108 */ f32 hopVerticalOffset;
     /* 0x010C */ s16 unk_10C;
     /* 0x010E */ char unk_10E[0x2];
-    /* 0x0110 */ CollisionData collision;
+    /* 0x0110 */ struct Collision collision;
     /* 0x0150 */ Mat3 unk_150;
     /* 0x0174 */ Mat3 orientationMatrix;
     /* 0x0198 */ KartTyre tyres[4];

--- a/include/macros.h
+++ b/include/macros.h
@@ -42,13 +42,6 @@
 
 // Avoid undefined behaviour for non-returning functions
 #ifdef __GNUC__
-#define NORETURN __attribute__((noreturn))
-#else
-#define NORETURN
-#endif
-
-// Avoid undefined behaviour for non-returning functions
-#ifdef __GNUC__
 #define NO_REORDER __attribute__((no_reorder))
 #else
 #define NO_REORDER

--- a/include/objects.h
+++ b/include/objects.h
@@ -205,7 +205,7 @@ extern s32 D_8018D1D8;
 //! Limit on some object type (ice chips?) in Sherbet Land
 extern s32 D_8018D3C0;
 
-extern CollisionData D_8018C0B0[];
+extern struct Collision D_8018C0B0[];
 
 /**
  * indexObjectList1, indexObjectList2, indexObjectList3, and indexObjectList4 are all lists of indices in gObjectList.

--- a/include/objects.h
+++ b/include/objects.h
@@ -205,7 +205,7 @@ extern s32 D_8018D1D8;
 //! Limit on some object type (ice chips?) in Sherbet Land
 extern s32 D_8018D3C0;
 
-extern Collision D_8018C0B0[];
+extern CollisionData D_8018C0B0[];
 
 /**
  * indexObjectList1, indexObjectList2, indexObjectList3, and indexObjectList4 are all lists of indices in gObjectList.

--- a/src/actors/falling_rock/update.inc.c
+++ b/src/actors/falling_rock/update.inc.c
@@ -42,7 +42,7 @@ void spawn_falling_rocks(struct ActorSpawnData* spawnData) {
         temp_v1 = (struct FallingRock*) GET_ACTOR(temp);
 
         temp_v1->unk_06 = temp_s0->someId;
-        func_802AAAAC((Collision*) &temp_v1->unk30);
+        func_802AAAAC((CollisionData*) &temp_v1->unk30);
         temp_s0++;
     }
 }

--- a/src/actors/falling_rock/update.inc.c
+++ b/src/actors/falling_rock/update.inc.c
@@ -42,7 +42,7 @@ void spawn_falling_rocks(struct ActorSpawnData* spawnData) {
         temp_v1 = (struct FallingRock*) GET_ACTOR(temp);
 
         temp_v1->unk_06 = temp_s0->someId;
-        func_802AAAAC((CollisionData*) &temp_v1->unk30);
+        func_802AAAAC((struct Collision*) &temp_v1->unk30);
         temp_s0++;
     }
 }

--- a/src/camera.h
+++ b/src/camera.h
@@ -23,7 +23,7 @@ typedef enum RenderMode {
     RENDER_TRACK_SECTIONS,
     RENDER_FULL_SCENE,
     RENDER_COLLISION_MESH
-};
+} RenderMode;
 
 typedef struct {
     f32 unk_0;
@@ -49,7 +49,7 @@ typedef struct {
     /* 0x48 */ s32 unk_48;
     /* 0x4C */ s32 unk_4C;
     /* 0x50 */ s32 unk_50;
-    /* 0x54 */ Collision collision;
+    /* 0x54 */ CollisionData collision;
     // When you hit a wall (or another driver) the camera's pos and lookAt bounce up and down. This is the velocity(?)
     // of that bouncing
     /* 0x94 */ UnkCameraInner unk_94;

--- a/src/camera.h
+++ b/src/camera.h
@@ -49,7 +49,7 @@ typedef struct {
     /* 0x48 */ s32 unk_48;
     /* 0x4C */ s32 unk_4C;
     /* 0x50 */ s32 unk_50;
-    /* 0x54 */ CollisionData collision;
+    /* 0x54 */ struct Collision collision;
     // When you hit a wall (or another driver) the camera's pos and lookAt bounce up and down. This is the velocity(?)
     // of that bouncing
     /* 0x94 */ UnkCameraInner unk_94;

--- a/src/code_80005FD0.c
+++ b/src/code_80005FD0.c
@@ -45,7 +45,7 @@
 #include "engine/RaceManager.h"
 
 s32 unk_code_80005FD0_pad[24];
-CollisionData D_80162E70;
+struct Collision D_80162E70;
 s16 D_80162EB0; // Possibly a float.
 s16 D_80162EB2; // possibly [3]
 
@@ -161,7 +161,7 @@ VehicleStuff gTankerTruckList[NUM_RACE_TANKER_TRUCKS];
 VehicleStuff gCarList[NUM_RACE_CARS];
 s32 D_80163DD8[4];
 BombKart gBombKarts[NUM_BOMB_KARTS_MAX];
-CollisionData gBombKartCollision[NUM_BOMB_KARTS_MAX];
+struct Collision gBombKartCollision[NUM_BOMB_KARTS_MAX];
 struct unexpiredActors gUnexpiredActorsList[8];
 CpuItemStrategyData cpu_ItemStrategy[8];
 s16 D_80164358;
@@ -2665,7 +2665,7 @@ s16 find_closest_vehicles_path_point(f32 xPos, UNUSED f32 yPos, f32 zPos, s16 wa
 
 s16 func_8000D24C(f32 posX, f32 posY, f32 posZ, s32* pathIndex) {
     UNUSED s32 pad;
-    CollisionData sp24;
+    struct Collision sp24;
 
     check_bounding_collision(&sp24, 10.0f, posX, posY, posZ);
     return find_closest_path_point_track_section(posX, posY, posZ, get_track_section_id(sp24.meshIndexZX), pathIndex);
@@ -2978,7 +2978,7 @@ s16 update_vehicle_following_path(Vec3f pos, s16* waypointIndex, f32 speed) {
 }
 
 void set_bomb_kart_spawn_positions(void) {
-    UNUSED CollisionData* var_s2;
+    UNUSED struct Collision* var_s2;
     f32 startingXPos;
     f32 startingZPos;
     f32 startingYPos;
@@ -3084,7 +3084,7 @@ void func_8000DF8C(s32 bombKartId) {
     TrackPathPoint* temp_v0_4;
     BombKart* bombKart;
     BombKart* bombKart2;
-    CollisionData* temp_a0_4;
+    struct Collision* temp_a0_4;
     Player* var_v0;
 
     bombKart = &gBombKarts[bombKartId];

--- a/src/code_80005FD0.c
+++ b/src/code_80005FD0.c
@@ -45,7 +45,7 @@
 #include "engine/RaceManager.h"
 
 s32 unk_code_80005FD0_pad[24];
-Collision D_80162E70;
+CollisionData D_80162E70;
 s16 D_80162EB0; // Possibly a float.
 s16 D_80162EB2; // possibly [3]
 
@@ -161,7 +161,7 @@ VehicleStuff gTankerTruckList[NUM_RACE_TANKER_TRUCKS];
 VehicleStuff gCarList[NUM_RACE_CARS];
 s32 D_80163DD8[4];
 BombKart gBombKarts[NUM_BOMB_KARTS_MAX];
-Collision gBombKartCollision[NUM_BOMB_KARTS_MAX];
+CollisionData gBombKartCollision[NUM_BOMB_KARTS_MAX];
 struct unexpiredActors gUnexpiredActorsList[8];
 CpuItemStrategyData cpu_ItemStrategy[8];
 s16 D_80164358;
@@ -2665,7 +2665,7 @@ s16 find_closest_vehicles_path_point(f32 xPos, UNUSED f32 yPos, f32 zPos, s16 wa
 
 s16 func_8000D24C(f32 posX, f32 posY, f32 posZ, s32* pathIndex) {
     UNUSED s32 pad;
-    Collision sp24;
+    CollisionData sp24;
 
     check_bounding_collision(&sp24, 10.0f, posX, posY, posZ);
     return find_closest_path_point_track_section(posX, posY, posZ, get_track_section_id(sp24.meshIndexZX), pathIndex);
@@ -2978,7 +2978,7 @@ s16 update_vehicle_following_path(Vec3f pos, s16* waypointIndex, f32 speed) {
 }
 
 void set_bomb_kart_spawn_positions(void) {
-    UNUSED Collision* var_s2;
+    UNUSED CollisionData* var_s2;
     f32 startingXPos;
     f32 startingZPos;
     f32 startingYPos;
@@ -3084,7 +3084,7 @@ void func_8000DF8C(s32 bombKartId) {
     TrackPathPoint* temp_v0_4;
     BombKart* bombKart;
     BombKart* bombKart2;
-    Collision* temp_a0_4;
+    CollisionData* temp_a0_4;
     Player* var_v0;
 
     bombKart = &gBombKarts[bombKartId];

--- a/src/code_80005FD0.h
+++ b/src/code_80005FD0.h
@@ -295,7 +295,7 @@ void func_8001C42C(void);
 
 /* This is where I'd put my static data, if I had any */
 
-extern CollisionData D_80162E70;
+extern struct Collision D_80162E70;
 extern s16 D_80162EB0; // Possibly a float.
 extern s16 D_80162EB2; // possibly [3]
 extern CPUBehaviour* gCoursesCPUBehaviour[];

--- a/src/code_80005FD0.h
+++ b/src/code_80005FD0.h
@@ -295,7 +295,7 @@ void func_8001C42C(void);
 
 /* This is where I'd put my static data, if I had any */
 
-extern Collision D_80162E70;
+extern CollisionData D_80162E70;
 extern s16 D_80162EB0; // Possibly a float.
 extern s16 D_80162EB2; // possibly [3]
 extern CPUBehaviour* gCoursesCPUBehaviour[];

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -294,7 +294,7 @@ const char** gLakituTexturePtr;
  */
 s32 indexObjectList4[32];
 //! Array of (4) Collisions?
-CollisionData D_8018C0B0[4];
+struct Collision D_8018C0B0[4];
 /**
  * List of object list indices used for:
  *   Moles in Moo Moo Farm
@@ -303,7 +303,7 @@ CollisionData D_8018C0B0[4];
  *   Potentially other things
  */
 s32 gObjectParticle1[gObjectParticle2_SIZE];
-CollisionData D_8018C3B0;
+struct Collision D_8018C3B0;
 /**
  * List of object list indices used for:
  * - Bats in Banshee's Boardwalk (but only 1 player mode?)
@@ -312,14 +312,14 @@ CollisionData D_8018C3B0;
  */
 s32 gObjectParticle2[gObjectParticle2_SIZE];
 // Maybe some unused Collision?
-UNUSED CollisionData D_8018C5F0;
+UNUSED struct Collision D_8018C5F0;
 /**
  * List of object list indices used for:
  * - Train index 1 smoke in Kalimari Desert
  * - Ferry index 1 smoke in DK Jungle
  */
 s32 gObjectParticle3[gObjectParticle3_SIZE];
-CollisionData D_8018C830;
+struct Collision D_8018C830;
 /**
  * List of object list indices. Used both for the fires in the DK Jungle cave
  * and, seemingly for the trail that shells leave behind them.

--- a/src/code_80057C60.c
+++ b/src/code_80057C60.c
@@ -294,7 +294,7 @@ const char** gLakituTexturePtr;
  */
 s32 indexObjectList4[32];
 //! Array of (4) Collisions?
-Collision D_8018C0B0[4];
+CollisionData D_8018C0B0[4];
 /**
  * List of object list indices used for:
  *   Moles in Moo Moo Farm
@@ -303,7 +303,7 @@ Collision D_8018C0B0[4];
  *   Potentially other things
  */
 s32 gObjectParticle1[gObjectParticle2_SIZE];
-Collision D_8018C3B0;
+CollisionData D_8018C3B0;
 /**
  * List of object list indices used for:
  * - Bats in Banshee's Boardwalk (but only 1 player mode?)
@@ -312,14 +312,14 @@ Collision D_8018C3B0;
  */
 s32 gObjectParticle2[gObjectParticle2_SIZE];
 // Maybe some unused Collision?
-UNUSED Collision D_8018C5F0;
+UNUSED CollisionData D_8018C5F0;
 /**
  * List of object list indices used for:
  * - Train index 1 smoke in Kalimari Desert
  * - Ferry index 1 smoke in DK Jungle
  */
 s32 gObjectParticle3[gObjectParticle3_SIZE];
-Collision D_8018C830;
+CollisionData D_8018C830;
 /**
  * List of object list indices. Used both for the fires in the DK Jungle cave
  * and, seemingly for the trail that shells leave behind them.

--- a/src/code_80057C60.h
+++ b/src/code_80057C60.h
@@ -404,14 +404,14 @@ extern const char* gLakituTextureBuffer[4][2];
 
 extern const char** gLakituTexturePtr;
 // extern s32 indexObjectList4[]; -> objects.h
-// extern CollisionData D_8018C0B0[]; -> objects.h
+// extern struct Collision D_8018C0B0[]; -> objects.h
 // extern s32 gObjectParticle1[]; -> objects.h
 
-extern CollisionData D_8018C3B0;
+extern struct Collision D_8018C3B0;
 // extern s32 gObjectParticle2[]; -> objects.h
 // extern s32 gObjectParticle3[]; -> objects.h
 
-extern CollisionData D_8018C830;
+extern struct Collision D_8018C830;
 // extern s32 gObjectParticle4[]; -> objects.h
 // extern s32 gLeafParticle[]; -> objects.h
 

--- a/src/code_80057C60.h
+++ b/src/code_80057C60.h
@@ -404,14 +404,14 @@ extern const char* gLakituTextureBuffer[4][2];
 
 extern const char** gLakituTexturePtr;
 // extern s32 indexObjectList4[]; -> objects.h
-// extern Collision D_8018C0B0[]; -> objects.h
+// extern CollisionData D_8018C0B0[]; -> objects.h
 // extern s32 gObjectParticle1[]; -> objects.h
 
-extern Collision D_8018C3B0;
+extern CollisionData D_8018C3B0;
 // extern s32 gObjectParticle2[]; -> objects.h
 // extern s32 gObjectParticle3[]; -> objects.h
 
-extern Collision D_8018C830;
+extern CollisionData D_8018C830;
 // extern s32 gObjectParticle4[]; -> objects.h
 // extern s32 gLeafParticle[]; -> objects.h
 

--- a/src/engine/Actor.h
+++ b/src/engine/Actor.h
@@ -23,7 +23,7 @@ public:
     /* 0x16 */ s16 Unk_16;
     /* 0x18 */ Vec3f Pos;
     /* 0x24 */ Vec3f Velocity = {0, 0, 0};
-    /* 0x30 */ CollisionData Unk30;
+    /* 0x30 */ struct Collision Unk30;
     /* 0x   */ const char* Model = "";
     uint8_t uuid[16];
     const char* Name = "";

--- a/src/engine/Actor.h
+++ b/src/engine/Actor.h
@@ -23,7 +23,7 @@ public:
     /* 0x16 */ s16 Unk_16;
     /* 0x18 */ Vec3f Pos;
     /* 0x24 */ Vec3f Velocity = {0, 0, 0};
-    /* 0x30 */ Collision Unk30;
+    /* 0x30 */ CollisionData Unk30;
     /* 0x   */ const char* Model = "";
     uint8_t uuid[16];
     const char* Name = "";

--- a/src/engine/CoreMath.h
+++ b/src/engine/CoreMath.h
@@ -151,7 +151,7 @@ struct IRotator {
         return *this;
     }
 
-    [[nodiscard]] void Set(uint16_t p, uint16_t y, uint16_t r) {
+    void Set(uint16_t p, uint16_t y, uint16_t r) {
         pitch = p;
         yaw = y;
         roll = r;

--- a/src/engine/Matrix.cpp
+++ b/src/engine/Matrix.cpp
@@ -59,14 +59,14 @@ void SetTextMatrix(Mat4 mf, f32 x, f32 y, f32 arg3, f32 arg4) {
 // AddMatrix but with custom gfx ptr arg and flags are predefined
 Gfx* AddTextMatrix(Gfx* displayListHead, Mat4 mtx) {
     // Push a new matrix to the stack
-    GetWorld()->Mtx.Objects.emplace_back();
+    GetWorld()->world_mtx.Objects.emplace_back();
 
     // Convert to a fixed-point matrix
-    FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &GetWorld()->Mtx.Objects.back());
-    guMtxF2L(mtx, &GetWorld()->Mtx.Objects.back());
+    FrameInterpolation_RecordMatrixMtxFToMtx((MtxF*)mtx, &GetWorld()->world_mtx.Objects.back());
+    guMtxF2L(mtx, &GetWorld()->world_mtx.Objects.back());
 
     // Load the matrix
-    gSPMatrix(displayListHead++, &GetWorld()->Mtx.Objects.back(), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPMatrix(displayListHead++, &GetWorld()->world_mtx.Objects.back(), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     return displayListHead;
 }
@@ -195,43 +195,43 @@ void AddLocalRotation(Mat4 mat, IRotator rot) {
 extern "C" {
 
     void AddHudMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(GetWorld()->Mtx.Objects, mtx, flags);
+        AddMatrix(GetWorld()->world_mtx.Objects, mtx, flags);
     }
 
     Mtx* GetScreenMatrix(void) {
-        return &GetWorld()->Mtx.Screen2D;
+        return &GetWorld()->world_mtx.Screen2D;
     }
 
     Mtx* GetOrthoMatrix(void) {
-        return &GetWorld()->Mtx.Ortho;
+        return &GetWorld()->world_mtx.Ortho;
     }
 
     Mtx* GetPerspMatrix(size_t cameraId) {
-        return &GetWorld()->Mtx.Persp[cameraId];
+        return &GetWorld()->world_mtx.Persp[cameraId];
     }
 
     Mtx* GetLookAtMatrix(size_t cameraId) {
-        return &GetWorld()->Mtx.LookAt[cameraId];
+        return &GetWorld()->world_mtx.LookAt[cameraId];
     }
 
     void AddObjectMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(GetWorld()->Mtx.Objects, mtx, flags);
+        AddMatrix(GetWorld()->world_mtx.Objects, mtx, flags);
     }
 
     Mtx* GetShadowMatrix(size_t playerId) {
-        return &GetWorld()->Mtx.Shadows[playerId];
+        return &GetWorld()->world_mtx.Shadows[playerId];
     }
 
     Mtx* GetKartMatrix(size_t playerId) {
-        return &GetWorld()->Mtx.Karts[playerId];
+        return &GetWorld()->world_mtx.Karts[playerId];
     }
 
     void AddEffectMatrix(Mat4 mtx, s32 flags) {
-        AddMatrix(GetWorld()->Mtx.Objects, mtx, flags);
+        AddMatrix(GetWorld()->world_mtx.Objects, mtx, flags);
     }
 
     void AddEffectMatrixOrtho(void) {
-        auto& stack = GetWorld()->Mtx.Objects;
+        auto& stack = GetWorld()->world_mtx.Objects;
         stack.emplace_back();
 
         guOrtho(&stack.back(), 0.0f, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1, 0.0f, -100.0f, 100.0f, 1.0f);
@@ -240,7 +240,7 @@ extern "C" {
     }
 
     Mtx* GetEffectMatrix(void) {
-        return GetMatrix(GetWorld()->Mtx.Objects);
+        return GetMatrix(GetWorld()->world_mtx.Objects);
     }
 
 
@@ -249,14 +249,14 @@ extern "C" {
      * We might need to adjust which ones we clear.
      */
     void ClearMatrixPools(void) {
-        GetWorld()->Mtx.Objects.clear();
-       // GetWorld()->Mtx.Shadows.clear();
-        //GetWorld()->Mtx.Karts.clear();
-       // GetWorld()->Mtx.Effects.clear();
+        GetWorld()->world_mtx.Objects.clear();
+       // GetWorld()->world_mtx.Shadows.clear();
+        //GetWorld()->world_mtx.Karts.clear();
+       // GetWorld()->world_mtx.Effects.clear();
     }
 
     void ClearObjectsMatrixPool(void) {
-        GetWorld()->Mtx.Objects.clear();
+        GetWorld()->world_mtx.Objects.clear();
     }
 }
 

--- a/src/engine/World.h
+++ b/src/engine/World.h
@@ -51,7 +51,7 @@ typedef struct Matrix {
     Matrix()
         : Hud(200), Objects(1000)
     {}
-};
+} Matrix;
 private:
     std::unique_ptr<Track> mTrack;
     Cup* CurrentCup;
@@ -112,7 +112,7 @@ public:
 
     void SetCurrentTrack(std::unique_ptr<Track> track);
 
-    Matrix Mtx;
+    Matrix world_mtx;
 
     std::vector<Cup*> Cups;
     size_t CupIndex = 1;

--- a/src/engine/objects/BombKart.h
+++ b/src/engine/objects/BombKart.h
@@ -41,7 +41,7 @@ class OBombKart : public OObject {
     u16 Unk_4A = 0;
     s16 Unk_4C = 1;
     f32 CenterY; // Center of the circle
-    CollisionData _Collision;
+    struct Collision _Collision;
 
 
     // This is simply a helper function to keep Spawning code clean

--- a/src/engine/objects/BombKart.h
+++ b/src/engine/objects/BombKart.h
@@ -41,7 +41,7 @@ class OBombKart : public OObject {
     u16 Unk_4A = 0;
     s16 Unk_4C = 1;
     f32 CenterY; // Center of the circle
-    Collision _Collision;
+    CollisionData _Collision;
 
 
     // This is simply a helper function to keep Spawning code clean

--- a/src/engine/tracks/DKJungle.cpp
+++ b/src/engine/tracks/DKJungle.cpp
@@ -134,7 +134,7 @@ void DKJungle::Load() {
     find_vtx_and_set_colours((Gfx*) d_course_dks_jungle_parkway_packed_dl_3FA8, 120, 255, 255, 255);
 }
 
-f32 DKJungle::GetWaterLevel(FVector pos, Collision* collision) {
+f32 DKJungle::GetWaterLevel(FVector pos, CollisionData* collision) {
     int32_t temp_v1 = get_track_section_id(collision->meshIndexZX) & 0xFF;
 
     if (temp_v1 == 0xFF) {

--- a/src/engine/tracks/DKJungle.cpp
+++ b/src/engine/tracks/DKJungle.cpp
@@ -134,7 +134,7 @@ void DKJungle::Load() {
     find_vtx_and_set_colours((Gfx*) d_course_dks_jungle_parkway_packed_dl_3FA8, 120, 255, 255, 255);
 }
 
-f32 DKJungle::GetWaterLevel(FVector pos, CollisionData* collision) {
+f32 DKJungle::GetWaterLevel(FVector pos, struct Collision* collision) {
     int32_t temp_v1 = get_track_section_id(collision->meshIndexZX) & 0xFF;
 
     if (temp_v1 == 0xFF) {

--- a/src/engine/tracks/DKJungle.h
+++ b/src/engine/tracks/DKJungle.h
@@ -24,7 +24,7 @@ public:
 //    virtual void Load(const char* courseVtx, 
 //                  course_texture* textures, const char* displaylists, size_t dlSize);
     virtual void Load() override;
-    virtual f32 GetWaterLevel(FVector pos, Collision* collision) override;
+    virtual f32 GetWaterLevel(FVector pos, CollisionData* collision) override;
     virtual void BeginPlay() override;
     virtual void InitTrackObjects() override;
     virtual void TickTrackObjects() override;

--- a/src/engine/tracks/DKJungle.h
+++ b/src/engine/tracks/DKJungle.h
@@ -24,7 +24,7 @@ public:
 //    virtual void Load(const char* courseVtx, 
 //                  course_texture* textures, const char* displaylists, size_t dlSize);
     virtual void Load() override;
-    virtual f32 GetWaterLevel(FVector pos, CollisionData* collision) override;
+    virtual f32 GetWaterLevel(FVector pos, struct Collision* collision) override;
     virtual void BeginPlay() override;
     virtual void InitTrackObjects() override;
     virtual void TickTrackObjects() override;

--- a/src/engine/tracks/SherbetLand.cpp
+++ b/src/engine/tracks/SherbetLand.cpp
@@ -132,7 +132,7 @@ void SherbetLand::Load() {
     find_vtx_and_set_colours((Gfx*) d_course_sherbet_land_packed_dl_2308, 150, 255, 255, 255);
 }
 
-f32 SherbetLand::GetWaterLevel(FVector pos, Collision* collision) {
+f32 SherbetLand::GetWaterLevel(FVector pos, CollisionData* collision) {
     if ((get_surface_type(collision->meshIndexZX) & 0xFF) == SNOW) {
         return (f32) (gTrackMinY - 0xA);
     }

--- a/src/engine/tracks/SherbetLand.cpp
+++ b/src/engine/tracks/SherbetLand.cpp
@@ -132,7 +132,7 @@ void SherbetLand::Load() {
     find_vtx_and_set_colours((Gfx*) d_course_sherbet_land_packed_dl_2308, 150, 255, 255, 255);
 }
 
-f32 SherbetLand::GetWaterLevel(FVector pos, CollisionData* collision) {
+f32 SherbetLand::GetWaterLevel(FVector pos, struct Collision* collision) {
     if ((get_surface_type(collision->meshIndexZX) & 0xFF) == SNOW) {
         return (f32) (gTrackMinY - 0xA);
     }

--- a/src/engine/tracks/SherbetLand.h
+++ b/src/engine/tracks/SherbetLand.h
@@ -24,7 +24,7 @@ public:
 //    virtual void Load(const char* courseVtx, 
 //                  course_texture* textures, const char* displaylists, size_t dlSize);
     virtual void Load() override;
-    virtual f32 GetWaterLevel(FVector pos, CollisionData* collision) override;
+    virtual f32 GetWaterLevel(FVector pos, struct Collision* collision) override;
     virtual void BeginPlay() override;
     virtual void TickTrackObjects() override;
     virtual void DrawTrackObjects(s32 cameraId) override;

--- a/src/engine/tracks/SherbetLand.h
+++ b/src/engine/tracks/SherbetLand.h
@@ -24,7 +24,7 @@ public:
 //    virtual void Load(const char* courseVtx, 
 //                  course_texture* textures, const char* displaylists, size_t dlSize);
     virtual void Load() override;
-    virtual f32 GetWaterLevel(FVector pos, Collision* collision) override;
+    virtual f32 GetWaterLevel(FVector pos, CollisionData* collision) override;
     virtual void BeginPlay() override;
     virtual void TickTrackObjects() override;
     virtual void DrawTrackObjects(s32 cameraId) override;

--- a/src/engine/tracks/Track.cpp
+++ b/src/engine/tracks/Track.cpp
@@ -550,7 +550,7 @@ void Track::Draw(ScreenContext* arg0) {
 void Track::DrawCredits() {
 }
 
-f32 Track::GetWaterLevel(FVector pos, CollisionData* collision) {
+f32 Track::GetWaterLevel(FVector pos, struct Collision* collision) {
     float highestWater = -FLT_MAX;
     bool found = false;
 

--- a/src/engine/tracks/Track.cpp
+++ b/src/engine/tracks/Track.cpp
@@ -550,7 +550,7 @@ void Track::Draw(ScreenContext* arg0) {
 void Track::DrawCredits() {
 }
 
-f32 Track::GetWaterLevel(FVector pos, Collision* collision) {
+f32 Track::GetWaterLevel(FVector pos, CollisionData* collision) {
     float highestWater = -FLT_MAX;
     bool found = false;
 

--- a/src/engine/tracks/Track.h
+++ b/src/engine/tracks/Track.h
@@ -366,7 +366,7 @@ public:
     virtual void Draw(ScreenContext*);
     virtual void DrawCredits();
     virtual void Waypoints(Player* player, int8_t playerId);
-    virtual f32 GetWaterLevel(FVector pos, CollisionData* collision);
+    virtual f32 GetWaterLevel(FVector pos, struct Collision* collision);
     virtual void Tick();
     // Draw transparent models (water, signs, arrows, etc.) 
     virtual void DrawTransparency(ScreenContext* screen, uint16_t pathCounter, uint16_t cameraRot,

--- a/src/engine/tracks/Track.h
+++ b/src/engine/tracks/Track.h
@@ -366,7 +366,7 @@ public:
     virtual void Draw(ScreenContext*);
     virtual void DrawCredits();
     virtual void Waypoints(Player* player, int8_t playerId);
-    virtual f32 GetWaterLevel(FVector pos, Collision* collision);
+    virtual f32 GetWaterLevel(FVector pos, CollisionData* collision);
     virtual void Tick();
     // Draw transparent models (water, signs, arrows, etc.) 
     virtual void DrawTransparency(ScreenContext* screen, uint16_t pathCounter, uint16_t cameraRot,

--- a/src/math_util_2.c
+++ b/src/math_util_2.c
@@ -436,7 +436,7 @@ s32 func_800418E8(f32 arg0, f32 arg1, Vec3f arg2) {
     return atan2s(arg0 - arg2[1], arg1 - arg2[2]);
 }
 
-s32 func_80041924(CollisionData* arg0, Vec3f arg1) {
+s32 func_80041924(struct Collision* arg0, Vec3f arg1) {
     s32 ret = 0;
 
     check_bounding_collision(arg0, 10.0f, arg1[0], arg1[1], arg1[2]);

--- a/src/math_util_2.c
+++ b/src/math_util_2.c
@@ -436,7 +436,7 @@ s32 func_800418E8(f32 arg0, f32 arg1, Vec3f arg2) {
     return atan2s(arg0 - arg2[1], arg1 - arg2[2]);
 }
 
-s32 func_80041924(Collision* arg0, Vec3f arg1) {
+s32 func_80041924(CollisionData* arg0, Vec3f arg1) {
     s32 ret = 0;
 
     check_bounding_collision(arg0, 10.0f, arg1[0], arg1[1], arg1[2]);

--- a/src/math_util_2.h
+++ b/src/math_util_2.h
@@ -59,7 +59,7 @@ s32 get_angle_between_xy(f32, f32, f32, f32);
 u16 func_800417B4(u16, u16);
 s32 func_800418AC(f32, f32, Vec3f);
 s32 func_800418E8(f32, f32, Vec3f);
-s32 func_80041924(Collision*, Vec3f);
+s32 func_80041924(CollisionData*, Vec3f);
 bool is_particle_on_screen(Vec3f, Camera*, u16);
 void func_800419F8(void);
 void mtfx_translation_x_y(Mat4, s32, s32);

--- a/src/math_util_2.h
+++ b/src/math_util_2.h
@@ -59,7 +59,7 @@ s32 get_angle_between_xy(f32, f32, f32, f32);
 u16 func_800417B4(u16, u16);
 s32 func_800418AC(f32, f32, Vec3f);
 s32 func_800418E8(f32, f32, Vec3f);
-s32 func_80041924(CollisionData*, Vec3f);
+s32 func_80041924(struct Collision*, Vec3f);
 bool is_particle_on_screen(Vec3f, Camera*, u16);
 void func_800419F8(void);
 void mtfx_translation_x_y(Mat4, s32, s32);

--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -821,7 +821,7 @@ void CM_ActorCollision(Player* player, Actor* actor) {
     }
 }
 
-f32 CM_GetWaterLevel(Vec3f pos, CollisionData* collision) {
+f32 CM_GetWaterLevel(Vec3f pos, struct Collision* collision) {
     FVector fPos = {pos[0], pos[1], pos[2]};
     return GetWorld()->GetTrack()->GetWaterLevel(fPos, collision);
 }

--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -821,7 +821,7 @@ void CM_ActorCollision(Player* player, Actor* actor) {
     }
 }
 
-f32 CM_GetWaterLevel(Vec3f pos, Collision* collision) {
+f32 CM_GetWaterLevel(Vec3f pos, CollisionData* collision) {
     FVector fPos = {pos[0], pos[1], pos[2]};
     return GetWorld()->GetTrack()->GetWaterLevel(fPos, collision);
 }

--- a/src/port/Game.h
+++ b/src/port/Game.h
@@ -168,7 +168,7 @@ void CM_ActorCollision(Player* player, struct Actor* actor);
 void CM_CleanCameras(void);
 void CM_CleanWorld(void);
 
-f32 CM_GetWaterLevel(Vec3f pos, CollisionData* collision);
+f32 CM_GetWaterLevel(Vec3f pos, struct Collision* collision);
 
 bool IsMarioRaceway();
 bool IsLuigiRaceway();

--- a/src/port/Game.h
+++ b/src/port/Game.h
@@ -168,7 +168,7 @@ void CM_ActorCollision(Player* player, struct Actor* actor);
 void CM_CleanCameras(void);
 void CM_CleanWorld(void);
 
-f32 CM_GetWaterLevel(Vec3f pos, Collision* collision);
+f32 CM_GetWaterLevel(Vec3f pos, CollisionData* collision);
 
 bool IsMarioRaceway();
 bool IsLuigiRaceway();

--- a/src/port/ui/UIWidgets.h
+++ b/src/port/ui/UIWidgets.h
@@ -37,7 +37,7 @@ namespace UIWidgets {
     void Tooltip(const char* text);
 
     // mostly in order for colors usable by the menu without custom text color
-    enum Colors {
+    typedef enum Colors {
         Red,
         DarkRed,
         Orange,
@@ -60,7 +60,7 @@ namespace UIWidgets {
         LightGray,
         White,
         NoColor
-    };
+    } Colors;
 
     const std::unordered_map<Colors, ImVec4> ColorValues = {
         { Colors::Pink, ImVec4(0.87f, 0.3f, 0.87f, 1.0f) },
@@ -149,8 +149,8 @@ namespace UIWidgets {
 
     struct CheckboxOptions : WidgetOptions {
         bool defaultValue = false; // Only applicable to CVarCheckbox
-        ComponentAlignment alignment = ComponentAlignment::Left;
-        LabelPosition labelPosition = LabelPosition::Near;
+        enum ComponentAlignment alignment = ComponentAlignment::Left;
+        enum LabelPosition labelPosition = LabelPosition::Near;
         Colors color = WidgetOptions::color = Colors::LightBlue;
 
         CheckboxOptions& DefaultValue(bool defaultValue_) {
@@ -178,8 +178,8 @@ namespace UIWidgets {
     struct ComboboxOptions : WidgetOptions {
         std::unordered_map<int32_t, const char*> comboMap = {};
         uint32_t defaultIndex = 0; // Only applicable to CVarCombobox
-        ComponentAlignment alignment = ComponentAlignment::Left;
-        LabelPosition labelPosition = LabelPosition::Above;
+        enum ComponentAlignment alignment = ComponentAlignment::Left;
+        enum LabelPosition labelPosition = LabelPosition::Above;
         ImGuiComboFlags flags = 0;
         Colors color = Colors::LightBlue;
 
@@ -216,8 +216,8 @@ namespace UIWidgets {
         int32_t min = 1;
         int32_t max = 10;
         int32_t defaultValue = 1;
-        ComponentAlignment alignment = ComponentAlignment::Left;
-        LabelPosition labelPosition = LabelPosition::Above;
+        enum ComponentAlignment alignment = ComponentAlignment::Left;
+        enum LabelPosition labelPosition = LabelPosition::Above;
         Colors color = Colors::Gray;
         ImGuiSliderFlags flags = 0;
 
@@ -271,8 +271,8 @@ namespace UIWidgets {
         float max = 10.0f;
         float defaultValue = 1.0f;
         bool isPercentage = false; // Multiplies visual value by 100
-        ComponentAlignment alignment = ComponentAlignment::Left;
-        LabelPosition labelPosition = LabelPosition::Above;
+        enum ComponentAlignment alignment = ComponentAlignment::Left;
+        enum LabelPosition labelPosition = LabelPosition::Above;
         Colors color = Colors::Gray;
         ImGuiSliderFlags flags = 0;
 

--- a/src/racing/actors.c
+++ b/src/racing/actors.c
@@ -405,7 +405,7 @@ void func_802976D8(Vec3s arg0) {
     arg0[2] = 0;
 }
 
-void func_802976EC(CollisionData* arg0, Vec3s arg1) {
+void func_802976EC(struct Collision* arg0, Vec3s arg1) {
     f32 x, y, z;
 
     if (arg0->unk34 == 0) {
@@ -953,8 +953,8 @@ void spawn_palm_trees(struct ActorSpawnData* spawnData) {
                 break;
         }
         CM_ActorGenerateCollision(temp_v1);
-        check_bounding_collision((CollisionData*) &temp_v1->unk30, 5.0f, temp_v1->pos[0], temp_v1->pos[1], temp_v1->pos[2]);
-        func_802976EC((CollisionData*) &temp_v1->unk30, temp_v1->rot);
+        check_bounding_collision((struct Collision*) &temp_v1->unk30, 5.0f, temp_v1->pos[0], temp_v1->pos[1], temp_v1->pos[2]);
+        func_802976EC((struct Collision*) &temp_v1->unk30, temp_v1->rot);
         temp_s0++;
     }
 }

--- a/src/racing/actors.c
+++ b/src/racing/actors.c
@@ -405,7 +405,7 @@ void func_802976D8(Vec3s arg0) {
     arg0[2] = 0;
 }
 
-void func_802976EC(Collision* arg0, Vec3s arg1) {
+void func_802976EC(CollisionData* arg0, Vec3s arg1) {
     f32 x, y, z;
 
     if (arg0->unk34 == 0) {
@@ -953,8 +953,8 @@ void spawn_palm_trees(struct ActorSpawnData* spawnData) {
                 break;
         }
         CM_ActorGenerateCollision(temp_v1);
-        check_bounding_collision((Collision*) &temp_v1->unk30, 5.0f, temp_v1->pos[0], temp_v1->pos[1], temp_v1->pos[2]);
-        func_802976EC((Collision*) &temp_v1->unk30, temp_v1->rot);
+        check_bounding_collision((CollisionData*) &temp_v1->unk30, 5.0f, temp_v1->pos[0], temp_v1->pos[1], temp_v1->pos[2]);
+        func_802976EC((CollisionData*) &temp_v1->unk30, temp_v1->rot);
         temp_s0++;
     }
 }

--- a/src/racing/actors.h
+++ b/src/racing/actors.h
@@ -15,7 +15,7 @@ void actor_not_rendered(Camera*, struct Actor*);
 void actor_rendered(Camera*, struct Actor*);
 void func_80297340(Camera*);
 void func_802976D8(Vec3s);
-void func_802976EC(CollisionData*, Vec3s);
+void func_802976EC(struct Collision*, Vec3s);
 void func_80297760(struct Actor*, Vec3f);
 void func_802977B0(Player*);
 void func_802977E4(Player*);

--- a/src/racing/actors.h
+++ b/src/racing/actors.h
@@ -15,7 +15,7 @@ void actor_not_rendered(Camera*, struct Actor*);
 void actor_rendered(Camera*, struct Actor*);
 void func_80297340(Camera*);
 void func_802976D8(Vec3s);
-void func_802976EC(Collision*, Vec3s);
+void func_802976EC(CollisionData*, Vec3s);
 void func_80297760(struct Actor*, Vec3f);
 void func_802977B0(Player*);
 void func_802977E4(Player*);

--- a/src/racing/actors_extended.c
+++ b/src/racing/actors_extended.c
@@ -17,7 +17,7 @@
 #include "sounds.h"
 #include "port/Game.h"
 
-void copy_collision(Collision* src, Collision* dest) {
+void copy_collision(CollisionData* src, CollisionData* dest) {
     dest->unk30 = src->unk30;
     dest->unk32 = src->unk32;
     dest->unk34 = src->unk34;

--- a/src/racing/actors_extended.c
+++ b/src/racing/actors_extended.c
@@ -17,7 +17,7 @@
 #include "sounds.h"
 #include "port/Game.h"
 
-void copy_collision(CollisionData* src, CollisionData* dest) {
+void copy_collision(struct Collision* src, struct Collision* dest) {
     dest->unk30 = src->unk30;
     dest->unk32 = src->unk32;
     dest->unk34 = src->unk34;

--- a/src/racing/actors_extended.h
+++ b/src/racing/actors_extended.h
@@ -6,7 +6,7 @@
 
 /** @cond */
 
-void copy_collision(CollisionData*, CollisionData*);
+void copy_collision(struct Collision*, struct Collision*);
 void triple_shell_actor_collide_with_player(struct ShellActor*, s32);
 void func_802B039C(struct BananaActor*);
 void func_802B0464(s16);

--- a/src/racing/actors_extended.h
+++ b/src/racing/actors_extended.h
@@ -6,7 +6,7 @@
 
 /** @cond */
 
-void copy_collision(Collision*, Collision*);
+void copy_collision(CollisionData*, CollisionData*);
 void triple_shell_actor_collide_with_player(struct ShellActor*, s32);
 void func_802B039C(struct BananaActor*);
 void func_802B0464(s16);

--- a/src/racing/collision.c
+++ b/src/racing/collision.c
@@ -28,7 +28,7 @@ void nullify_displaylist(uintptr_t addr) {
     macro->words.w1 = 0;
 }
 
-void func_802AAAAC(CollisionData* collision) {
+void func_802AAAAC(struct Collision* collision) {
     collision->meshIndexYX = 5000;
     collision->meshIndexZY = 5000;
     collision->meshIndexZX = 5000;
@@ -47,7 +47,7 @@ f32 get_water_level(Player* player) {
     return CM_GetWaterLevel(player->pos, &player->collision);
 }
 
-s32 check_collision_zx(CollisionData* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
+s32 check_collision_zx(struct Collision* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
     CollisionTriangle* triangle = &gCollisionMesh[index];
     UNUSED f32 pad;
     f32 x3;
@@ -156,7 +156,7 @@ s32 check_collision_zx(CollisionData* collision, f32 boundingBoxSize, f32 posX, 
     return 0;
 }
 
-s32 check_collision_yx(CollisionData* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
+s32 check_collision_yx(struct Collision* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
     CollisionTriangle* triangle = &gCollisionMesh[index];
     UNUSED f32 pad[6];
     f32 x3;
@@ -264,7 +264,7 @@ s32 check_collision_yx(CollisionData* collision, f32 boundingBoxSize, f32 posX, 
     return 0;
 }
 
-s32 check_collision_zy(CollisionData* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
+s32 check_collision_zy(struct Collision* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
     CollisionTriangle* triangle = &gCollisionMesh[index];
     s32 b = true;
     UNUSED f32 pad[7];
@@ -471,7 +471,7 @@ f32 calculate_surface_height(f32 x, f32 y, f32 z, u16 index) {
     return ((triangle->normalX * x) + (triangle->normalZ * z) + triangle->distance) / -triangle->normalY;
 }
 
-f32 func_802ABEAC(CollisionData* collision, Vec3f pos) {
+f32 func_802ABEAC(struct Collision* collision, Vec3f pos) {
     if (collision->unk34 == 1) {
         return calculate_surface_height(pos[0], pos[1], pos[2], collision->meshIndexZX);
     }
@@ -530,7 +530,7 @@ void process_shell_collision(Vec3f pos, UNUSED f32 boundingBoxSize, Vec3f veloci
     velocity[2] = z * scaleFactor;
 }
 
-void shell_collision(CollisionData* collision, Vec3f velocity) {
+void shell_collision(struct Collision* collision, Vec3f velocity) {
     if (collision->surfaceDistance[0] < 0.0f) {
         process_shell_collision(collision->unk48, collision->surfaceDistance[0], velocity, 2.0f);
     }
@@ -580,7 +580,7 @@ void adjust_pos_orthogonally(Vec3f pos1, f32 boundingBoxSize, Vec3f pos2, UNUSED
 }
 
 UNUSED s32 detect_tyre_collision(KartTyre* tyre) {
-    CollisionData collision;
+    struct Collision collision;
     UNUSED s32 pad[12];
     s32 trackLengthX;
     s32 trackLengthZ;
@@ -695,7 +695,7 @@ UNUSED s32 detect_tyre_collision(KartTyre* tyre) {
     // depending on which (if any) if statements were entered on the loop's last cycle
 }
 
-s32 is_colliding_with_drivable_surface(CollisionData* collision, f32 boundingBoxSize, f32 newX, f32 newY, f32 newZ,
+s32 is_colliding_with_drivable_surface(struct Collision* collision, f32 boundingBoxSize, f32 newX, f32 newY, f32 newZ,
                                        u16 index, f32 oldX, f32 oldY, f32 oldZ) {
     CollisionTriangle* triangle = &gCollisionMesh[index];
     UNUSED s32 pad;
@@ -810,7 +810,7 @@ s32 is_colliding_with_drivable_surface(CollisionData* collision, f32 boundingBox
 /**
  * Wall collision
  */
-s32 is_colliding_with_wall2(CollisionData* arg, f32 boundingBoxSize, f32 x1, f32 y1, f32 z1, u16 surfaceIndex, f32 posX,
+s32 is_colliding_with_wall2(struct Collision* arg, f32 boundingBoxSize, f32 x1, f32 y1, f32 z1, u16 surfaceIndex, f32 posX,
                             f32 posY, f32 posZ) {
     if (CVarGetInteger("gNoWallColision", 0)) {
         return NO_COLLISION;
@@ -995,7 +995,7 @@ s32 is_colliding_with_wall2(CollisionData* arg, f32 boundingBoxSize, f32 x1, f32
 /**
  * This is actually more like colliding with face X/Y/Z
  */
-s32 is_colliding_with_wall1(CollisionData* arg, f32 boundingBoxSize, f32 x1, f32 y1, f32 z1, u16 surfaceIndex, f32 posX,
+s32 is_colliding_with_wall1(struct Collision* arg, f32 boundingBoxSize, f32 x1, f32 y1, f32 z1, u16 surfaceIndex, f32 posX,
                             f32 posY, f32 posZ) {
     if (CVarGetInteger("gNoWallColision", 0)) {
         return NO_COLLISION;
@@ -1178,7 +1178,7 @@ s32 is_colliding_with_wall1(CollisionData* arg, f32 boundingBoxSize, f32 x1, f32
     return COLLISION;
 }
 
-u16 actor_terrain_collision(CollisionData* collision, f32 boundingBoxSize, f32 newX, f32 newY, f32 newZ, f32 oldX, f32 oldY,
+u16 actor_terrain_collision(struct Collision* collision, f32 boundingBoxSize, f32 newX, f32 newY, f32 newZ, f32 oldX, f32 oldY,
                             f32 oldZ) {
     s32 trackLengthX;
     s32 trackLengthZ;
@@ -1296,7 +1296,7 @@ u16 actor_terrain_collision(CollisionData* collision, f32 boundingBoxSize, f32 n
     return flags;
 }
 
-u16 check_bounding_collision(CollisionData* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ) {
+u16 check_bounding_collision(struct Collision* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ) {
     u16 numTriangles;
     s32 trackLengthX;
     s32 trackLengthZ;
@@ -2236,8 +2236,8 @@ void subtract_scaled_vector(Vec3f pos1, f32 boundingBoxSize, Vec3f pos2) {
 }
 
 u16 player_terrain_collision(Player* player, KartTyre* tyre, f32 tyre2X, f32 tyre2Y, f32 tyre2Z) {
-    CollisionData wtf;
-    CollisionData* collision = &wtf;
+    struct Collision wtf;
+    struct Collision* collision = &wtf;
     UNUSED s32 pad;
     u16 i;
     u16 meshIndex;

--- a/src/racing/collision.c
+++ b/src/racing/collision.c
@@ -28,7 +28,7 @@ void nullify_displaylist(uintptr_t addr) {
     macro->words.w1 = 0;
 }
 
-void func_802AAAAC(Collision* collision) {
+void func_802AAAAC(CollisionData* collision) {
     collision->meshIndexYX = 5000;
     collision->meshIndexZY = 5000;
     collision->meshIndexZX = 5000;
@@ -47,7 +47,7 @@ f32 get_water_level(Player* player) {
     return CM_GetWaterLevel(player->pos, &player->collision);
 }
 
-s32 check_collision_zx(Collision* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
+s32 check_collision_zx(CollisionData* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
     CollisionTriangle* triangle = &gCollisionMesh[index];
     UNUSED f32 pad;
     f32 x3;
@@ -156,7 +156,7 @@ s32 check_collision_zx(Collision* collision, f32 boundingBoxSize, f32 posX, f32 
     return 0;
 }
 
-s32 check_collision_yx(Collision* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
+s32 check_collision_yx(CollisionData* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
     CollisionTriangle* triangle = &gCollisionMesh[index];
     UNUSED f32 pad[6];
     f32 x3;
@@ -264,7 +264,7 @@ s32 check_collision_yx(Collision* collision, f32 boundingBoxSize, f32 posX, f32 
     return 0;
 }
 
-s32 check_collision_zy(Collision* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
+s32 check_collision_zy(CollisionData* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ, u16 index) {
     CollisionTriangle* triangle = &gCollisionMesh[index];
     s32 b = true;
     UNUSED f32 pad[7];
@@ -471,7 +471,7 @@ f32 calculate_surface_height(f32 x, f32 y, f32 z, u16 index) {
     return ((triangle->normalX * x) + (triangle->normalZ * z) + triangle->distance) / -triangle->normalY;
 }
 
-f32 func_802ABEAC(Collision* collision, Vec3f pos) {
+f32 func_802ABEAC(CollisionData* collision, Vec3f pos) {
     if (collision->unk34 == 1) {
         return calculate_surface_height(pos[0], pos[1], pos[2], collision->meshIndexZX);
     }
@@ -530,7 +530,7 @@ void process_shell_collision(Vec3f pos, UNUSED f32 boundingBoxSize, Vec3f veloci
     velocity[2] = z * scaleFactor;
 }
 
-void shell_collision(Collision* collision, Vec3f velocity) {
+void shell_collision(CollisionData* collision, Vec3f velocity) {
     if (collision->surfaceDistance[0] < 0.0f) {
         process_shell_collision(collision->unk48, collision->surfaceDistance[0], velocity, 2.0f);
     }
@@ -580,7 +580,7 @@ void adjust_pos_orthogonally(Vec3f pos1, f32 boundingBoxSize, Vec3f pos2, UNUSED
 }
 
 UNUSED s32 detect_tyre_collision(KartTyre* tyre) {
-    Collision collision;
+    CollisionData collision;
     UNUSED s32 pad[12];
     s32 trackLengthX;
     s32 trackLengthZ;
@@ -695,7 +695,7 @@ UNUSED s32 detect_tyre_collision(KartTyre* tyre) {
     // depending on which (if any) if statements were entered on the loop's last cycle
 }
 
-s32 is_colliding_with_drivable_surface(Collision* collision, f32 boundingBoxSize, f32 newX, f32 newY, f32 newZ,
+s32 is_colliding_with_drivable_surface(CollisionData* collision, f32 boundingBoxSize, f32 newX, f32 newY, f32 newZ,
                                        u16 index, f32 oldX, f32 oldY, f32 oldZ) {
     CollisionTriangle* triangle = &gCollisionMesh[index];
     UNUSED s32 pad;
@@ -810,7 +810,7 @@ s32 is_colliding_with_drivable_surface(Collision* collision, f32 boundingBoxSize
 /**
  * Wall collision
  */
-s32 is_colliding_with_wall2(Collision* arg, f32 boundingBoxSize, f32 x1, f32 y1, f32 z1, u16 surfaceIndex, f32 posX,
+s32 is_colliding_with_wall2(CollisionData* arg, f32 boundingBoxSize, f32 x1, f32 y1, f32 z1, u16 surfaceIndex, f32 posX,
                             f32 posY, f32 posZ) {
     if (CVarGetInteger("gNoWallColision", 0)) {
         return NO_COLLISION;
@@ -995,7 +995,7 @@ s32 is_colliding_with_wall2(Collision* arg, f32 boundingBoxSize, f32 x1, f32 y1,
 /**
  * This is actually more like colliding with face X/Y/Z
  */
-s32 is_colliding_with_wall1(Collision* arg, f32 boundingBoxSize, f32 x1, f32 y1, f32 z1, u16 surfaceIndex, f32 posX,
+s32 is_colliding_with_wall1(CollisionData* arg, f32 boundingBoxSize, f32 x1, f32 y1, f32 z1, u16 surfaceIndex, f32 posX,
                             f32 posY, f32 posZ) {
     if (CVarGetInteger("gNoWallColision", 0)) {
         return NO_COLLISION;
@@ -1178,7 +1178,7 @@ s32 is_colliding_with_wall1(Collision* arg, f32 boundingBoxSize, f32 x1, f32 y1,
     return COLLISION;
 }
 
-u16 actor_terrain_collision(Collision* collision, f32 boundingBoxSize, f32 newX, f32 newY, f32 newZ, f32 oldX, f32 oldY,
+u16 actor_terrain_collision(CollisionData* collision, f32 boundingBoxSize, f32 newX, f32 newY, f32 newZ, f32 oldX, f32 oldY,
                             f32 oldZ) {
     s32 trackLengthX;
     s32 trackLengthZ;
@@ -1296,7 +1296,7 @@ u16 actor_terrain_collision(Collision* collision, f32 boundingBoxSize, f32 newX,
     return flags;
 }
 
-u16 check_bounding_collision(Collision* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ) {
+u16 check_bounding_collision(CollisionData* collision, f32 boundingBoxSize, f32 posX, f32 posY, f32 posZ) {
     u16 numTriangles;
     s32 trackLengthX;
     s32 trackLengthZ;
@@ -2236,8 +2236,8 @@ void subtract_scaled_vector(Vec3f pos1, f32 boundingBoxSize, Vec3f pos2) {
 }
 
 u16 player_terrain_collision(Player* player, KartTyre* tyre, f32 tyre2X, f32 tyre2Y, f32 tyre2Z) {
-    Collision wtf;
-    Collision* collision = &wtf;
+    CollisionData wtf;
+    CollisionData* collision = &wtf;
     UNUSED s32 pad;
     u16 i;
     u16 meshIndex;

--- a/src/racing/collision.h
+++ b/src/racing/collision.h
@@ -7,25 +7,25 @@
 #define NO_COLLISION 0x0
 
 void nullify_displaylist(uintptr_t);
-void func_802AAAAC(Collision*);
+void func_802AAAAC(CollisionData*);
 f32 get_water_level(Player*);
-s32 check_collision_zx(Collision*, f32, f32, f32, f32, u16);
-s32 check_collision_yx(Collision*, f32, f32, f32, f32, u16);
-s32 check_collision_zy(Collision*, f32, f32, f32, f32, u16);
+s32 check_collision_zx(CollisionData*, f32, f32, f32, f32, u16);
+s32 check_collision_yx(CollisionData*, f32, f32, f32, f32, u16);
+s32 check_collision_zy(CollisionData*, f32, f32, f32, f32, u16);
 s8 get_surface_type(u16);
 s16 get_track_section_id(u16);
 s16 func_802ABD7C(u16);
 s16 func_802ABDB8(u16);
 s16 func_802ABDF4(u16);
 f32 calculate_surface_height(f32, f32, f32, u16);
-f32 func_802ABEAC(Collision*, Vec3f);
-void shell_collision(Collision*, Vec3f);
+f32 func_802ABEAC(CollisionData*, Vec3f);
+void shell_collision(CollisionData*, Vec3f);
 void process_shell_collision(Vec3f, f32, Vec3f, f32);
 u16 player_terrain_collision(Player*, KartTyre*, f32, f32, f32);
 void adjust_pos_orthogonally(Vec3f, f32, Vec3f, f32);
 s32 detect_tyre_collision(KartTyre*);
-u16 actor_terrain_collision(Collision*, f32, f32, f32, f32, f32, f32, f32);
-u16 check_bounding_collision(Collision*, f32, f32, f32, f32);
+u16 actor_terrain_collision(CollisionData*, f32, f32, f32, f32, f32, f32, f32);
+u16 check_bounding_collision(CollisionData*, f32, f32, f32, f32);
 f32 spawn_actor_on_surface(f32, f32, f32);
 void set_vtx_buffer(uintptr_t, u32, u32);
 void add_vtx_from_quadrangle(Vtx* vert, size_t count);

--- a/src/racing/collision.h
+++ b/src/racing/collision.h
@@ -7,25 +7,25 @@
 #define NO_COLLISION 0x0
 
 void nullify_displaylist(uintptr_t);
-void func_802AAAAC(CollisionData*);
+void func_802AAAAC(struct Collision*);
 f32 get_water_level(Player*);
-s32 check_collision_zx(CollisionData*, f32, f32, f32, f32, u16);
-s32 check_collision_yx(CollisionData*, f32, f32, f32, f32, u16);
-s32 check_collision_zy(CollisionData*, f32, f32, f32, f32, u16);
+s32 check_collision_zx(struct Collision*, f32, f32, f32, f32, u16);
+s32 check_collision_yx(struct Collision*, f32, f32, f32, f32, u16);
+s32 check_collision_zy(struct Collision*, f32, f32, f32, f32, u16);
 s8 get_surface_type(u16);
 s16 get_track_section_id(u16);
 s16 func_802ABD7C(u16);
 s16 func_802ABDB8(u16);
 s16 func_802ABDF4(u16);
 f32 calculate_surface_height(f32, f32, f32, u16);
-f32 func_802ABEAC(CollisionData*, Vec3f);
-void shell_collision(CollisionData*, Vec3f);
+f32 func_802ABEAC(struct Collision*, Vec3f);
+void shell_collision(struct Collision*, Vec3f);
 void process_shell_collision(Vec3f, f32, Vec3f, f32);
 u16 player_terrain_collision(Player*, KartTyre*, f32, f32, f32);
 void adjust_pos_orthogonally(Vec3f, f32, Vec3f, f32);
 s32 detect_tyre_collision(KartTyre*);
-u16 actor_terrain_collision(CollisionData*, f32, f32, f32, f32, f32, f32, f32);
-u16 check_bounding_collision(CollisionData*, f32, f32, f32, f32);
+u16 actor_terrain_collision(struct Collision*, f32, f32, f32, f32, f32, f32, f32);
+u16 check_bounding_collision(struct Collision*, f32, f32, f32, f32);
 f32 spawn_actor_on_surface(f32, f32, f32);
 void set_vtx_buffer(uintptr_t, u32, u32);
 void add_vtx_from_quadrangle(Vtx* vert, size_t count);

--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -1348,7 +1348,7 @@ UNUSED void func_8004A5E4(Vec3f arg0, Vec3su arg1, f32 arg2, u8* texture, Vtx* a
     func_8004A414(arg0, arg1, arg2, texture, arg4, 16, 16, 16, 16);
 }
 
-void func_8004A630(CollisionData* arg0, Vec3f arg1, f32 arg2) {
+void func_8004A630(struct Collision* arg0, Vec3f arg1, f32 arg2) {
     if (func_80041924(arg0, arg1) != 0) {
         D_80183E50[0] = arg1[0];
         D_80183E50[1] = calculate_surface_height(arg1[0], 0.0f, arg1[2], arg0->meshIndexZX) + 0.8;

--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -1348,7 +1348,7 @@ UNUSED void func_8004A5E4(Vec3f arg0, Vec3su arg1, f32 arg2, u8* texture, Vtx* a
     func_8004A414(arg0, arg1, arg2, texture, arg4, 16, 16, 16, 16);
 }
 
-void func_8004A630(Collision* arg0, Vec3f arg1, f32 arg2) {
+void func_8004A630(CollisionData* arg0, Vec3f arg1, f32 arg2) {
     if (func_80041924(arg0, arg1) != 0) {
         D_80183E50[0] = arg1[0];
         D_80183E50[1] = calculate_surface_height(arg1[0], 0.0f, arg1[2], arg0->meshIndexZX) + 0.8;

--- a/src/render_objects.h
+++ b/src/render_objects.h
@@ -167,7 +167,7 @@ void func_8004A488(Vec3f, Vec3su, f32, u8*, Vtx*, s32, s32, s32, s32);
 void func_8004A4FC(Vec3f, Vec3su, f32, u8*, Vtx*, s32, s32, s32, s32);
 void func_8004A570(Vec3f, Vec3su, f32, u8*, Vtx*, s32, s32, s32, s32);
 void func_8004A5E4(Vec3f, Vec3su, f32, u8*, Vtx*);
-void func_8004A630(Collision*, Vec3f, f32);
+void func_8004A630(CollisionData*, Vec3f, f32);
 void func_8004A6EC(s32, f32);
 void func_8004A7AC(s32, f32);
 void func_8004A9B8(f32);

--- a/src/render_objects.h
+++ b/src/render_objects.h
@@ -167,7 +167,7 @@ void func_8004A488(Vec3f, Vec3su, f32, u8*, Vtx*, s32, s32, s32, s32);
 void func_8004A4FC(Vec3f, Vec3su, f32, u8*, Vtx*, s32, s32, s32, s32);
 void func_8004A570(Vec3f, Vec3su, f32, u8*, Vtx*, s32, s32, s32, s32);
 void func_8004A5E4(Vec3f, Vec3su, f32, u8*, Vtx*);
-void func_8004A630(CollisionData*, Vec3f, f32);
+void func_8004A630(struct Collision*, Vec3f, f32);
 void func_8004A6EC(s32, f32);
 void func_8004A7AC(s32, f32);
 void func_8004A9B8(f32);


### PR DESCRIPTION
I added actual names to some structs (RenderMode, Matrix, ...) and made sure usage was unambigious for others (LabelPosition, ComponentAlignment, Collision).

I've also renamed one variable, `World::Mtx` as that name was colliding with something else.

On Linux (gcc 15.3.0), I was getting a warning regarding the `noreturn` keyword and it's (re-)declaration. That was fixed too.