### PR TITLE
CI: run the x86 PR build natively instead of under QEMU

### DIFF
--- a/.github/workflows/linux-compile.yml
+++ b/.github/workflows/linux-compile.yml
@@ -152,11 +152,6 @@ jobs:
           fetch-tags: true
           submodules: recursive
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/386
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
Follow-up from the discussion on #715 about the 2 hour PR validation times.

The `build-docker-x86` job in `linux-compile.yml` registers a QEMU binfmt handler for `linux/386` before building. Since i386 containers run natively on the amd64 runners, that registration only forces every binary in the container through the qemu-i386 emulator, which is where the ~170 minutes go.

`main.yml`'s `build-linux-x86-docker` job (added in the same PR, #697) is identical except it never installs QEMU, and it has been completing in 13-18 minutes. This change just makes the PR job match it by removing the setup-qemu step. The `--platform linux/386` image and all build steps are unchanged.

This PR's own validation run should demonstrate the difference directly, so I have left it in draft until the numbers are in.