### PR TITLE
Don't let the attract timer hijack an in-flight menu fade

### DIFF
--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -2847,7 +2847,11 @@ void func_80095574(void) {
     if (gMenuTimingCounter == DEBUG_MENU_DEBUG_MODE) {
         play_sound2(SOUND_INTRO_WELCOME);
     }
-    if (gMenuTimingCounter >= 0x12D) {
+    // Don't arm the demo reel while another fade is in flight: pressing start
+    // in the last moments before the attract timeout let this overwrite the
+    // press-start fade's gMenuFadeType mid-fade, hijacking it into the demo
+    // with the menu music already faded out. (Vanilla bug.)
+    if (gMenuTimingCounter >= 0x12D && is_screen_being_faded() == 0) {
         func_8009E230();
         func_800CA0A0();
     }


### PR DESCRIPTION
**Bug (vanilla):** pressing start on the splash screen in the last moments before the demo timeout plays the enter chime but then drops into the demo reel with no music. The attract timer (gMenuTimingCounter >= 0x12D) fires while the press-start fade is still in flight and overwrites the fade target, so the fade completes as a demo entry instead of the main menu. The window is roughly 0.7 seconds every attract cycle, so in normal play it shows up as a rare "pressed start and got the silent demo" glitch.

**Fix:** only arm the demo when no other fade is in flight. A natural timeout (idle, no fade running) behaves exactly as before.

**Verification (macOS, Apple Silicon):** the timing window is hard to hit by hand, so I tested with a temporary debug rig that forces the attract timer to its trigger a few frames after a start press, making the collision happen on every press.
- Unfixed + rig: every start press gave the chime followed by the silent demo reel.
- Fixed + rig: every start press landed in the main menu with music, and the rig logged the blocked collision each time.
- Clean build containing only this change: immediate start press, normal start press, and the natural idle demo reel all behave as usual.
