### PR TITLE
Package the macOS nightly as a .dmg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,8 +114,15 @@ jobs:
           wget -O $APP/Contents/Resources/gamecontrollerdb.txt https://raw.githubusercontent.com/mdqinc/SDL_GameControllerDB/master/gamecontrollerdb.txt
           codesign --force --deep --sign - --options runtime --entitlements cmake/macos/entitlements.plist $APP
           mkdir spaghetti-${{ matrix.config }}
-          # Zip with ditto so the executable bit survives artifact upload.
-          ditto -c -k --keepParent $APP spaghetti-${{ matrix.config }}/SpaghettiKart.app.zip
+          # Ship a .dmg like the other HarbourMasters macOS ports: a disk image
+          # survives GitHub's own artifact zip intact, so the download expands in
+          # one step and the app can be dragged straight to Applications.
+          STAGE=dmg-staging
+          mkdir -p $STAGE
+          ditto $APP $STAGE/SpaghettiKart.app
+          ln -s /Applications $STAGE/Applications
+          hdiutil create -volname SpaghettiKart -srcfolder $STAGE -ov -format UDZO spaghetti-${{ matrix.config }}/SpaghettiKart.dmg
+          cp README.md spaghetti-${{ matrix.config }}/readme.txt
       - name: Publish packaged artifacts
         if: matrix.config == 'Release'
         uses: actions/upload-artifact@v4
@@ -155,8 +162,15 @@ jobs:
           wget -O $APP/Contents/Resources/gamecontrollerdb.txt https://raw.githubusercontent.com/mdqinc/SDL_GameControllerDB/master/gamecontrollerdb.txt
           codesign --force --deep --sign - --options runtime --entitlements cmake/macos/entitlements.plist $APP
           mkdir spaghetti-${{ matrix.config }}
-          # Zip with ditto so the executable bit survives artifact upload.
-          ditto -c -k --keepParent $APP spaghetti-${{ matrix.config }}/SpaghettiKart.app.zip
+          # Ship a .dmg like the other HarbourMasters macOS ports: a disk image
+          # survives GitHub's own artifact zip intact, so the download expands in
+          # one step and the app can be dragged straight to Applications.
+          STAGE=dmg-staging
+          mkdir -p $STAGE
+          ditto $APP $STAGE/SpaghettiKart.app
+          ln -s /Applications $STAGE/Applications
+          hdiutil create -volname SpaghettiKart -srcfolder $STAGE -ov -format UDZO spaghetti-${{ matrix.config }}/SpaghettiKart.dmg
+          cp README.md spaghetti-${{ matrix.config }}/readme.txt
       - name: Publish packaged artifacts
         if: matrix.config == 'Release'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Follow up to #724 and #734.

**Currently, the download arrives as a zip inside a zip + throws an error upon unzip**

I missed this in #724. GitHub wraps every artifact in a zip of its own, so pre-zipping the .app leaves the nightly as a zip containing another zip. Archive Utility also tries to expand the inner one by itself and reports "Unable to expand SpaghettiKart.app.zip. It is in an unsupported format." Nothing is actually damaged, and the app opens on a second double click, but it is a confusing first impression.

I added the ditto zip to keep the executable bit, and that turns out not to be necessary. actions/upload-artifact has stored Unix modes since v4, and the bundle has no symlinks. Both checked before changing anything: the pre-#724 artifact stores `-rwxr-xr-x` for the bare binary, and a plain zip round trip of the .app keeps the executable bit with `codesign --verify --deep --strict` still passing.

Building a disk image instead lines the port up with Shipwright and the other macOS ports. The artifact holds SpaghettiKart.dmg and readme.txt, and the mounted image has the app next to an Applications shortcut for drag to install.

Tested by running this workflow on a fork. Both macOS jobs pass, and for each architecture the artifact expands in one step to the dmg and readme, mounts with the app and an Applications shortcut, keeps the executable bit, and verifies with `codesign --verify --deep --strict`.

Signing is unchanged, so an unsigned nightly still needs the usual right click Open on first launch.

(This originally also fixed the Windows README links, but #742 landed the same fix first, so it's rebased down to just the packaging change. The readme.txt inside the disk image now picks up the fixed links from main.)