### PR TITLE
Fix menu fizzle-out transition ending instantly

### DIFF
--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -5750,7 +5750,7 @@ void func_8009E0F0(s32 arg0) {
         if (gTransitionDuration[4] >= 0x100U) {
             gTransitionDuration[4] = 0x000000FF;
         }
-        gCurrentTransitionTime[4] = arg0;
+        gCurrentTransitionTime[4] = 0;
         for (var_v0 = 0; var_v0 < 0x4B0; var_v0++) {
             sTKMK00_LowResBuffer[var_v0] = 0;
         }


### PR DESCRIPTION
Backing out of the game select menu (B button) is supposed to play the classic dissolve transition, but it currently skips straight to the previous screen, which also cuts off the back sound.

Root cause: `func_8009E0F0` starts the fizzle-out with `gCurrentTransitionTime[4] = arg0`. In the decomp this line zeroes the timer (`D_8018E7E0 = 0`, the scalar that the out-of-bounds `gCurrentTransitionTime[4]` index lands on). The `= arg0` slipped in with the renames in #309, so the timer starts at the full duration and the very first frame considers the transition finished.

The fix sets the timer back to 0, matching the other three transition starters (`func_8009DEF8`, `func_8009DF8C`, `func_8009E17C`), which already zero it.

Tested on macOS: the dissolve plays over the full 20 frames and the back sound completes.