### PR TITLE
Content browser: fix crash by moving data assets into a disabled section

### DIFF
--- a/src/port/ui/ContentBrowser.cpp
+++ b/src/port/ui/ContentBrowser.cpp
@@ -20,6 +20,7 @@
 #include "port/Game.h"
 #include "src/engine/editor/SceneManager.h"
 #include "engine/TrackBrowser.h"
+#include <fast/resource/ResourceType.h>
 
 #include "engine/World.h"
 
@@ -30,6 +31,23 @@ extern "C" {
 }
 
 namespace TrackEditor {
+
+namespace {
+// The browser lists archive paths by name, and the archive holds plenty of
+// non-model data (track sections, paths, CPU tables). Feeding one of those to
+// the renderer walks it as display list commands and crashes.
+bool IsDisplayListAsset(const std::string& path) {
+    auto rm = Ship::Context::GetRawInstance()->GetResourceManager();
+    if (rm == nullptr) {
+        return false;
+    }
+    auto res = rm->LoadResource(path);
+    if (res == nullptr || res->GetInitData() == nullptr) {
+        return false;
+    }
+    return static_cast<Fast::ResourceType>(res->GetInitData()->Type) == Fast::ResourceType::DisplayList;
+}
+} // namespace
     bool bIsTrainWindowOpen = false; // Global because member variables do not work in lambdas
 
     ContentBrowserWindow::~ContentBrowserWindow() {
@@ -45,6 +63,7 @@ namespace TrackEditor {
         if (Refresh) {
             Refresh = false;
             Content.clear();
+            NonSpawnableContent.clear();
             TrackBrowser::Instance->Refresh(gTrackRegistry);
             FindContent();
             return;
@@ -223,6 +242,25 @@ void ContentBrowserWindow::AddActorContent(std::string search) {
             }
             i_custom += 1;
         }
+
+        if (!NonSpawnableContent.empty()) {
+            ImGui::NewLine();
+            ImGui::Separator();
+            ImGui::TextDisabled("Not spawnable (data assets)");
+            ImGui::BeginDisabled();
+            size_t i_data = 0;
+            for (const auto& file : NonSpawnableContent) {
+                if (!search.empty() && ToLower(file).find(search) == std::string::npos) {
+                    continue;
+                }
+                if ((i_data != 0) && (i_data % 5 != 0)) {
+                    ImGui::SameLine();
+                }
+                ImGui::Button(fmt::format("{}##data{}", file, i_data).c_str());
+                i_data += 1;
+            }
+            ImGui::EndDisabled();
+        }
     }
 
     void ContentBrowserWindow::FindContent() {
@@ -249,6 +287,13 @@ void ContentBrowserWindow::AddActorContent(std::string search) {
                     continue;
                 } else if (file.find('.') != std::string::npos) {
                     // File has an extension
+                    continue;
+                }
+
+                // Only models can be spawned; the archive also holds data assets
+                // (track sections, paths) that would be drawn as garbage.
+                if (!IsDisplayListAsset(file)) {
+                    NonSpawnableContent.push_back(file);
                     continue;
                 }
 

--- a/src/port/ui/ContentBrowser.h
+++ b/src/port/ui/ContentBrowser.h
@@ -11,6 +11,7 @@ public:
     ~ContentBrowserWindow();
 
     std::vector<std::string> Content;
+    std::vector<std::string> NonSpawnableContent;
 
     bool Refresh = true;
 


### PR DESCRIPTION
Clicking certain entries in the HM64 Labs content browser crashes the game. tracks/harbour/data_track_sections reproduces it every time.

The Custom tab builds its list from archive paths by name, skipping a few patterns like /mat_ and _tri_N, and gives everything else a spawn button. The archive also holds things that are not models though: track sections, paths, CPU tables. Clicking one of those hands it to AddStaticMeshActor and the renderer walks it as display list commands. In the crash I traced, the "vertex pointer" it ended up dereferencing was eight bytes of a font filename.

This checks the resource type instead of the name. Assets that are not display lists move into a disabled "Not spawnable (data assets)" section rather than being dropped from the list, so they are still findable and it is obvious why they do nothing.

Tested on macOS: the crashing entry no longer crashes, models still spawn as before, and the disabled list populates and clears correctly on refresh.
