### PR TITLE
Freecam fix for Metal: accept keyboard and mouse input on the Metal backend

### DIFF
--- a/src/enhancements/freecam/freecam.cpp
+++ b/src/enhancements/freecam/freecam.cpp
@@ -188,7 +188,8 @@ bool FreecamKeyDown(int virtualKey) {
     static bool prevKeyState[256] = { false }; // Store previous key states
     bool isDownNow = false;
 
-    if (wnd->GetWindowBackend() == Fast::WindowBackend::FAST3D_SDL_OPENGL) {
+    if (wnd->GetWindowBackend() == Fast::WindowBackend::FAST3D_SDL_OPENGL ||
+        wnd->GetWindowBackend() == Fast::WindowBackend::FAST3D_SDL_METAL) {
         // Use SDL to check key states
         const uint8_t* keystate = SDL_GetKeyboardState(NULL);
         isDownNow = keystate[virtualKey] != 0;
@@ -308,7 +309,8 @@ void freecam_keyboard_manager(Camera* camera, Vec3f forwardVector) {
         // Keyboard/mouse OpenGL/SDL
     }
 #endif
-    else if (wnd->GetWindowBackend() == Fast::WindowBackend::FAST3D_SDL_OPENGL) {
+    else if (wnd->GetWindowBackend() == Fast::WindowBackend::FAST3D_SDL_OPENGL ||
+             wnd->GetWindowBackend() == Fast::WindowBackend::FAST3D_SDL_METAL) {
         const uint8_t* keystate = SDL_GetKeyboardState(NULL);
         if (FreecamKeyDown(SDL_SCANCODE_F)) {
             fTargetPlayer = !fTargetPlayer;


### PR DESCRIPTION
Freecam's keyboard and mouse handling is gated on FAST3D_SDL_OPENGL. The default renderer on macOS is Metal, so the gate never passes and none of the keys or mouse look do anything. Controller input still works because it goes through a separate path, which is why this reads as "freecam is broken" rather than "freecam is missing".

Both call sites now accept Metal alongside OpenGL. Both are plain SDL_GetKeyboardState and mouse paths with nothing backend specific inside them, so the check was simply narrower than it needed to be.

Tested on macOS with the Metal backend: movement keys, mouse look, fast move and the player targeting keys all work. Other backends are untouched, the OpenGL and DX11 branches are unchanged.
