### PR TITLE
Add Luigi Raceway 64 sign gap fix to the Fix Visuals toggle

### DIFF
--- a/src/engine/tracks/LuigiRaceway.cpp
+++ b/src/engine/tracks/LuigiRaceway.cpp
@@ -123,7 +123,7 @@ static void ApplySignSeamFix() {
     if (vtx == NULL) {
         return;
     }
-    vtx[10].v.ob[0] = CVarGetInteger("gEnhancements.Fixes.LuigiRacewaySignSeam", 0) ? -223 : -222;
+    vtx[10].v.ob[0] = CVarGetInteger("gFixVisuals", 0) ? -223 : -222;
 }
 
 void LuigiRaceway::Load() {

--- a/src/engine/tracks/LuigiRaceway.cpp
+++ b/src/engine/tracks/LuigiRaceway.cpp
@@ -9,6 +9,7 @@
 #include "align_asset_macro.h"
 #include "engine/objects/BombKart.h"
 #include "assets/models/tracks/luigi_raceway/luigi_raceway_data.h"
+#include "assets/models/tracks/luigi_raceway/luigi_raceway_vertices.h"
 #include "assets/other/tracks/luigi_raceway/luigi_raceway_data.h"
 #include "engine/objects/HotAirBalloon.h"
 #include "engine/actors/Finishline.h"
@@ -115,8 +116,19 @@ LuigiRaceway::LuigiRaceway() {
     Props.Sequence = MusicSeq::MUSIC_SEQ_LUIGI_RACEWAY;
 }
 
+// Two vertices of the 64 sign differ by one unit in X, splitting the triangle
+// ring that meets there and leaving an uncovered sliver. Snapping them closes it.
+static void ApplySignSeamFix() {
+    Vtx* vtx = (Vtx*) ResourceGetDataByName(d_course_luigi_raceway_vertex_0x0400B2C0);
+    if (vtx == NULL) {
+        return;
+    }
+    vtx[10].v.ob[0] = CVarGetInteger("gEnhancements.Fixes.LuigiRacewaySignSeam", 0) ? -223 : -222;
+}
+
 void LuigiRaceway::Load() {
     Track::Load();
+    ApplySignSeamFix();
     if (gIsMirrorMode != 0) {
         for (size_t i = 0; i < ARRAY_COUNT(luigi_raceway_dls); i++) {
             InvertTriangleWindingByName(luigi_raceway_dls[i]);

--- a/src/port/ui/PortMenu.cpp
+++ b/src/port/ui/PortMenu.cpp
@@ -377,10 +377,6 @@ void PortMenu::AddEnhancements() {
     AddWidget(path, "Disable Rubberbanding", WIDGET_CVAR_CHECKBOX)
         .CVar("gDisableRubberbanding")
         .Options(CheckboxOptions().Tooltip("Disable rubberbanding in the game."));
-    AddWidget(path, "Fix Luigi Raceway sign gap", WIDGET_CVAR_CHECKBOX)
-        .CVar("gEnhancements.Fixes.LuigiRacewaySignSeam")
-        .Options(CheckboxOptions().Tooltip(
-            "Closes the see-through gap in the 64 sign (takes effect after track reload)."));
     AddWidget(path, "Far Frustrum", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gFarFrustrum")
         .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger("gNoCulling", 0); })
@@ -411,7 +407,8 @@ void PortMenu::AddEnhancements() {
         .Options(CheckboxOptions().Tooltip("Press C-Left to look behind you"));
     AddWidget(path, "Fix Visuals", WIDGET_CVAR_CHECKBOX)
         .CVar("gFixVisuals")
-        .Options(CheckboxOptions().Tooltip("Fixes the second last lamp glow in Banshee Boardwalk"));
+        .Options(CheckboxOptions().Tooltip("Fixes minor visual bugs: the second last lamp glow in Banshee Boardwalk, "
+                                           "and the gap in the Luigi Raceway 64 sign (applies at track load)."));
 
     AddRulesets();
 

--- a/src/port/ui/PortMenu.cpp
+++ b/src/port/ui/PortMenu.cpp
@@ -377,6 +377,10 @@ void PortMenu::AddEnhancements() {
     AddWidget(path, "Disable Rubberbanding", WIDGET_CVAR_CHECKBOX)
         .CVar("gDisableRubberbanding")
         .Options(CheckboxOptions().Tooltip("Disable rubberbanding in the game."));
+    AddWidget(path, "Fix Luigi Raceway sign gap", WIDGET_CVAR_CHECKBOX)
+        .CVar("gEnhancements.Fixes.LuigiRacewaySignSeam")
+        .Options(CheckboxOptions().Tooltip(
+            "Closes the see-through gap in the 64 sign (takes effect after track reload)."));
     AddWidget(path, "Far Frustrum", WIDGET_CVAR_SLIDER_FLOAT)
         .CVar("gFarFrustrum")
         .PreFunc([](WidgetInfo& info) { info.isHidden = !CVarGetInteger("gNoCulling", 0); })


### PR DESCRIPTION
The blue 64 sign on Luigi Raceway has a see-through sliver cutting through the lower half of the 6. Two vertices of the sign's front face share texture coordinates but sit one unit apart in X, so the five triangles meeting at that point split into two rings and leave a wedge with no coverage. The back face is intact, which is why the hole shows the background instead of the sign's own blue.

The mismatch is in the original game's data. In the extracted archive, d_course_luigi_raceway_vertex_0x0400B2C0 has vertex [10] at (-222, 5, 344) and vertex [16] at (-223, 5, 344), both with st (686, 765). Snapping [10] to match [16] closes the ring.

Since this edits original geometry it stays opt-in: it is part of the existing Fix Visuals toggle (default off). The patch runs at track load and writes the vanilla value back when the toggle is off, so stock behavior is untouched.

Tested on macOS: with the toggle on the sign renders whole, and toggling it off and reloading brings the gap back.

Vanilla:
<img width="215" height="235" alt="Vanilla" src="https://github.com/user-attachments/assets/9bf11eb5-c7dc-406d-9370-7db1218e7792" />

Enhancement Toggled:
<img width="217" height="221" alt="Patched" src="https://github.com/user-attachments/assets/ac8d9684-d0c3-4ac5-b2fb-d4e70c869b3a" />
