### PR TITLE
Fix: Reset battle bomb kart overlays when a race starts

### DIFF
--- a/src/code_8006E9C0.c
+++ b/src/code_8006E9C0.c
@@ -487,6 +487,9 @@ void init_object_list_index(void) {
     // for (loopIndex = 0; loopIndex < NUM_BOMB_KARTS_VERSUS; loopIndex++) {
     //     find_unused_obj_index(&gIndexObjectBombKart[loopIndex]);
     // }
+    for (loopIndex = 0; loopIndex < 4; loopIndex++) {
+        CM_DisplayBattleBombKart(loopIndex, 0);
+    }
 }
 
 Vtx cloudvtx[4][4] = { {


### PR DESCRIPTION
After a 3 or 4 player battle where a knocked out player turned into a bomb, selecting Retry on the results screen started the new battle with that player's character and the bomb drawn merged together. Reported on Discord (Linux/Steam Deck) and reproduced on macOS on current main.

<!-- screenshot: character and bomb merged after Retry -->

The original game kept the battle bomb karts in gObjectList, which reset_object_variable() zeroes at every race start, so a retried battle always began with the bombs hidden. The port moved them to persistent World state that is only reset during load_track(). Retry reuses the already loaded track and skips load_track, so the active bomb overlays carried into the new battle.

This change disables the overlays in init_object_list_index(), which runs at every race start for every screen mode, at the same spot where the original game re-initialized the bomb kart object slots (the commented out loop directly above).

Verified by reproducing on stock main (4 player battle played to the end, then Retry) and confirming the overlay no longer appears with this change. Players knocked out mid-battle still become bombs normally, since the reset only runs at race start.

<img width="392" height="371" alt="Screenshot 2026-08-17 at 11 10 10 AM" src="https://github.com/user-attachments/assets/ba29db6b-2f80-4d5d-9f3f-7fd78804aba2" />