### PR TITLE
Fix track music not stopping after Retry in 3/4P modes + integrate into existing Multiplayer feature toggle

### DIFF
--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -2603,6 +2603,9 @@ void func_800C76C0(u8 playerId) {
                             break;
                         case 2: /* switch 2 */
                             if ((D_800EA0EC[0] == 1) && (D_800EA0EC[1] == 1) && (D_800EA0EC[2] == 1)) {
+                                // @port Fade out the course music the port enables in 3P/4P splitscreen
+                                func_800C3448(0x100100FF);
+                                func_800C3448(0x110100FF);
                                 func_800C5278(5U);
                                 func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0x80, 0x26));
                                 play_sequence2(MUSIC_SEQ_VS_BATTLE_RESULTS);
@@ -2614,6 +2617,8 @@ void func_800C76C0(u8 playerId) {
                         case 3: /* switch 2 */
                             if ((D_800EA0EC[0] == 1) && (D_800EA0EC[1] == 1) && (D_800EA0EC[2] == 1) &&
                                 (D_800EA0EC[3] == 1)) {
+                                func_800C3448(0x100100FF);
+                                func_800C3448(0x110100FF);
                                 func_800C5278(5U);
                                 func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0x80, 0x26));
                                 play_sequence2(MUSIC_SEQ_VS_BATTLE_RESULTS);

--- a/src/port/ui/PortMenu.cpp
+++ b/src/port/ui/PortMenu.cpp
@@ -363,7 +363,8 @@ void PortMenu::AddEnhancements() {
     AddSidebarEntry("Enhancements", "General", 3);
     AddWidget(path, "No multiplayer feature cuts", WIDGET_CVAR_CHECKBOX)
         .CVar("gMultiplayerNoFeatureCuts")
-        .Options(CheckboxOptions().Tooltip("Allows full train and jumbotron in multiplayer, etc."));
+        .Options(CheckboxOptions().Tooltip(
+            "Allows full train and jumbotron in multiplayer, course music in 3P/4P modes, etc."));
     AddWidget(path, "Widescreen portrait spacing", WIDGET_CVAR_CHECKBOX)
         .CVar("gBetterResultPortraits")
         .Options(CheckboxOptions().Tooltip("Alters result portrait spacing for better aesthetics on widescreen"));

--- a/src/racing/race_logic.c
+++ b/src/racing/race_logic.c
@@ -425,10 +425,11 @@ void func_8028EC38(s32 arg0) {
 
 void func_8028EC98(s32 arg0) {
 
-    // We want music in multiplayer, so this was removed
-    //if (gScreenModeSelection == SCREEN_MODE_3P_4P_SPLITSCREEN) {
-    //    return;
-    //}
+    // @port The original game skips course music in 3P/4P splitscreen; the
+    // "No multiplayer feature cuts" enhancement restores it.
+    if (!CVarGetInteger("gMultiplayerNoFeatureCuts", 0) && (gScreenModeSelection == SCREEN_MODE_3P_4P_SPLITSCREEN)) {
+        return;
+    }
 
     func_800029B0();
 

--- a/src/racing/race_logic.c
+++ b/src/racing/race_logic.c
@@ -1060,6 +1060,8 @@ void func_80290338(void) {
     gQuitToMenuTransitionCounter = 5;
     gGotoMode = MAIN_MENU_FROM_QUIT;
     gTourComplete = false;
+    // @port Fade the music players out; the original relied on the audio session reset for this
+    func_800CA330(0x19);
 }
 
 // Driver Change
@@ -1068,6 +1070,7 @@ void func_80290360(void) {
     gQuitToMenuTransitionCounter = 5;
     gGotoMode = PLAYER_SELECT_MENU_FROM_QUIT;
     gTourComplete = false;
+    func_800CA330(0x19);
 }
 
 // Course Change
@@ -1076,6 +1079,7 @@ void func_80290388(void) {
     gQuitToMenuTransitionCounter = 5;
     gGotoMode = COURSE_SELECT_MENU_FROM_QUIT;
     gTourComplete = false;
+    func_800CA330(0x19);
 }
 
 // Retry
@@ -1084,6 +1088,7 @@ void func_802903B0(void) {
     gQuitToMenuTransitionCounter = 5;
     gGotoMode = RACING;
     gTourComplete = false;
+    func_800CA330(0x19);
     // Stop when retrying
     if(HMAS_IsPlaying(HMAS_MUSIC)) {
         HMAS_Stop(HMAS_MUSIC);


### PR DESCRIPTION
In 3 and 4 player battles, the track music keeps playing over the results screen music, and selecting Retry starts a second overlapping copy of the track music on top of it. Quitting from the results screen also carries music into the main menu, which is the behavior reported in #293.

Given the original game doesn't start track music in 3P/4P splitscreen (play_music_for_current_track returns early for that screen mode, confirmed in the decomp), its battle results code only fades the music players in the 2 player case, the only case that had track music to fade. Scene changes on the original relied on a full audio session reset that the port skips. With the port's multiplayer music enabled, nothing stops the track music at the results screen or when leaving a race or battle.

The first commit fades the music players in the 3P and 4P battle results cases the same way the 2P case already does, and adds the same fade the menus use (func_800CA330 with the same timing) to the four race exit paths: Retry, Quit, Course Change, and Driver Change. That covers the results screen overlap, the stacking after Retry, and the leak into the main menu.

Fixes #293

The second commit ties the 3P/4P track music to the existing No multiplayer feature cuts toggle rather than adding a separate one, being mindful of coco875's preference per PR #750 for grouping enhancements into general toggles. (for now) With the toggle off, which is the default currently, 3P/4P splitscreen goes back to the original silence, and with the toggle enabled, the track music plays with the fades from the first commit. I realize this changes the default multiplayer functionality back to vanilla, so totally open to removing this commit, untying it from the toggle entirely or instead giving the music its own toggle. Let me know!

Verified on macOS: 4 player battle results now fade the track music and play the results theme alone, repeated retries stay clean, quitting to the main menu leaves only the menu music, leaving No multiplayer feature cuts off gives a silent 3P/4P battle with the fanfare and results theme intact, turning it on brings the track music back with the same clean fades, and a GP race start, finish, and quit sound unchanged.
