### PR TITLE
Fix: 3/4P pause menu and splitscreen text drift on wide windows

### DIFF
--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -7686,12 +7686,20 @@ void func_800A2EB8(MenuItem* arg0) {
     s32 leftShift;
     s32 rightShift;
 
-    // @port Keep each results column centered over its half of the window; this
-    // screen parks ranks 1-4 in the right half and ranks 5-8 in the left half.
-    // print_letter culls glyphs that start outside the vanilla 320 wide area,
-    // so clamp on very wide windows.
-    leftShift = get_left_half_center() - 80;
-    rightShift = get_right_half_center() - 240;
+    // @port Keep each results column over its half of the window; this screen
+    // parks ranks 1-4 in the right half and ranks 5-8 in the left half. The
+    // baseline keeps vanilla's anchors (a 4:3 window renders unchanged); Fix
+    // Visuals centers the rank rows truly on their halves (vanilla parks them
+    // on x=225 and x=88, slightly toward the middle). print_letter culls
+    // glyphs that start outside the vanilla 320 wide area, so clamp on very
+    // wide windows.
+    if (CVarGetInteger("gFixVisuals", 0) == true) {
+        leftShift = get_left_half_center() - 88;
+        rightShift = get_right_half_center() - 225;
+    } else {
+        leftShift = get_left_half_center() - 80;
+        rightShift = get_right_half_center() - 240;
+    }
     if (leftShift < -25) {
         leftShift = -25;
     }
@@ -7778,11 +7786,18 @@ void func_800A34A8(MenuItem* arg0) {
     s32 leftShift;
     s32 rightShift;
 
-    // @port Keep each tally column centered over its half of the window; the
-    // vanilla columns center them on a 4:3 screen. print_letter culls glyphs
-    // that start outside the vanilla 320 wide area, so clamp on very wide windows.
-    leftShift = get_left_half_center() - 80;
-    rightShift = get_right_half_center() - 240;
+    // @port Keep each tally column over its half of the window. The baseline
+    // keeps vanilla's anchors (a 4:3 window renders unchanged); Fix Visuals
+    // centers the rows truly on their halves (vanilla parks them on x=86 and
+    // x=248, slightly toward the middle). print_letter culls glyphs that
+    // start outside the vanilla 320 wide area, so clamp on very wide windows.
+    if (CVarGetInteger("gFixVisuals", 0) == true) {
+        leftShift = get_left_half_center() - 82;
+        rightShift = get_right_half_center() - 231;
+    } else {
+        leftShift = get_left_half_center() - 80;
+        rightShift = get_right_half_center() - 240;
+    }
     if (leftShift < -25) {
         leftShift = -25;
     }
@@ -8729,18 +8744,40 @@ void render_menu_item_end_course_option(MenuItem* arg0) {
 }
 
 void func_800A6034(MenuItem* arg0) {
-    char* text;
+    char* cupText;
+    char* courseText;
+    s32 rightShift;
+    s32 maxShift;
+    s32 cupHalf;
+    s32 courseHalf;
 
     if (D_801657E8 != true) {
+        // @port Follow the fourth viewport's black panel, which stretches to the
+        // window edge. The baseline keeps vanilla's anchor (a 4:3 window renders
+        // unchanged); Fix Visuals centers the text truly on the panel (vanilla
+        // parks it on x = 160 + 0x41 = 225, slightly left of center).
+        // print_letter culls glyphs that start past the vanilla 320 area, so
+        // back off just enough to keep the wider line intact.
+        cupText = gCupNames[D_800DC540];
+        courseText = CM_GetProps()->Name;
+        if (CVarGetInteger("gFixVisuals", 0) == true) {
+            rightShift = get_right_half_center() - (160 + 0x41);
+        } else {
+            rightShift = get_right_half_center() - 240;
+        }
+        cupHalf = (s32) (get_string_width(cupText) * 0.85f) / 2;
+        courseHalf = (s32) (get_string_width(courseText) * 0.65f) / 2;
+        maxShift = (SCREEN_WIDTH - 2) - (cupHalf > courseHalf ? cupHalf : courseHalf) - (160 + 0x41);
+        if (rightShift > maxShift) {
+            rightShift = maxShift;
+        }
         gDPSetPrimColor(gDisplayListHead++, 0, 0, 0x00, 0x00, 0x00, arg0->param1);
-        text = gCupNames[D_800DC540];
         set_text_color(TEXT_BLUE_GREEN_RED_CYCLE_2);
-        print_text1_center_mode_2(arg0->column + 0x41, arg0->row + 0xA0, text, 0, 0.85f, 1.0f);
-        text = CM_GetProps()->Name;
+        print_text1_center_mode_2(arg0->column + rightShift + 0x41, arg0->row + 0xA0, cupText, 0, 0.85f, 1.0f);
         //! @warning this used to be gCurrentCourseId % 4
         // Hopefully this is equivallent.
         set_text_color((s32) TrackBrowser_GetTrackIndex() % 4);
-        print_text1_center_mode_2(arg0->column + 0x41, arg0->row + 0xC3, text, 0, 0.65f, 0.85f);
+        print_text1_center_mode_2(arg0->column + rightShift + 0x41, arg0->row + 0xC3, courseText, 0, 0.65f, 0.85f);
     }
 }
 

--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -7665,6 +7665,17 @@ void func_800A2D1C(MenuItem* arg0) {
     }
 }
 
+// @port In splitscreen the viewports split at the center of the window, but the
+// vanilla 2D text coordinates assume a 4:3 screen, so on wider windows text drawn
+// over the side viewports drifts toward the middle (issue #285).
+static f32 get_left_half_center(void) {
+    return (OTRGetDimensionFromLeftEdge(0) + (SCREEN_WIDTH / 2)) / 2.0f;
+}
+
+static f32 get_right_half_center(void) {
+    return (OTRGetDimensionFromRightEdge(SCREEN_WIDTH) + (SCREEN_WIDTH / 2)) / 2.0f;
+}
+
 void func_800A2EB8(MenuItem* arg0) {
     s8 sp70[8];
     UNUSED s32 stackPadding0;
@@ -7672,16 +7683,31 @@ void func_800A2EB8(MenuItem* arg0) {
     s32 temp_s0;
     s32 var_a0;
     s32 var_s2;
+    s32 leftShift;
+    s32 rightShift;
+
+    // @port Keep each results column centered over its half of the window; this
+    // screen parks ranks 1-4 in the right half and ranks 5-8 in the left half.
+    // print_letter culls glyphs that start outside the vanilla 320 wide area,
+    // so clamp on very wide windows.
+    leftShift = get_left_half_center() - 80;
+    rightShift = get_right_half_center() - 240;
+    if (leftShift < -25) {
+        leftShift = -25;
+    }
+    if (rightShift > 32) {
+        rightShift = 32;
+    }
 
     for (var_s2 = 0; var_s2 < NUM_PLAYERS; var_s2++) {
         sp70[var_s2] = gPlayers[gGPCurrentRacePlayerIdByRank[var_s2]].characterId;
     }
     set_text_color(TEXT_BLUE_GREEN_RED_CYCLE_1);
-    print_text_mode_1(arg0->column + 0x1E, arg0->row + 0x19, "results", 0, 1.0f, 1.0f);
+    print_text_mode_1(arg0->column + rightShift + 0x1E, arg0->row + 0x19, "results", 0, 1.0f, 1.0f);
     set_text_color(TEXT_BLUE_GREEN_RED_CYCLE_2);
-    print_text_mode_1(arg0->column + 0x2C, arg0->row + 0x28, "round", 0, 0.7f, 0.7f);
+    print_text_mode_1(arg0->column + rightShift + 0x2C, arg0->row + 0x28, "round", 0, 0.7f, 0.7f);
     convert_number_to_ascii(GetCupCursorPosition() + 1, sp68);
-    print_text_mode_1(arg0->column + 0x57, arg0->row + 0x28, &sp68[1], 0, 0.7f, 0.7f);
+    print_text_mode_1(arg0->column + rightShift + 0x57, arg0->row + 0x28, &sp68[1], 0, 0.7f, 0.7f);
     for (var_s2 = 0; var_s2 < 4; var_s2++) {
         if (gGPCurrentRacePlayerIdByRank[var_s2] < gPlayerCount) {
             var_a0 = (s32) gGlobalTimer % 3;
@@ -7689,7 +7715,7 @@ void func_800A2EB8(MenuItem* arg0) {
             var_a0 = TEXT_YELLOW;
         }
         set_text_color(var_a0);
-        func_800A32B4(arg0->column + 7, arg0->row + (0x10 * var_s2) + 0x38, (s32) sp70[var_s2], var_s2);
+        func_800A32B4(arg0->column + rightShift + 7, arg0->row + (0x10 * var_s2) + 0x38, (s32) sp70[var_s2], var_s2);
     }
     for (var_s2 = 4; var_s2 < 8; var_s2++) {
         if (gGPCurrentRacePlayerIdByRank[var_s2] < gPlayerCount) {
@@ -7698,16 +7724,17 @@ void func_800A2EB8(MenuItem* arg0) {
             var_a0 = TEXT_YELLOW;
         }
         set_text_color(var_a0);
-        func_800A32B4(0xBE - arg0->column, arg0->row + (0x10 * var_s2) + 0x5A, sp70[var_s2], var_s2);
+        func_800A32B4((0xBE + leftShift) - arg0->column, arg0->row + (0x10 * var_s2) + 0x5A, sp70[var_s2], var_s2);
     }
     set_text_color(TEXT_BLUE_GREEN_RED_CYCLE_2);
     temp_s0 = (s32) (((f32) (get_string_width(GetCupName()) + 8) * 0.6f) /
                      2); //  gCupNames[GetCupIndex()]) + 8) * 0.6f) / 2);
     print_text1_center_mode_1(
-        (-(s32) (((f32) (get_string_width(D_800E76CC[gCCSelection]) + 8) * 0.6f) / 2) - arg0->column) + 0xF5,
+        (-(s32) (((f32) (get_string_width(D_800E76CC[gCCSelection]) + 8) * 0.6f) / 2) - arg0->column) + leftShift +
+            0xF5,
         arg0->row + 0xE1, gCupNames[D_800DC540], 0, 0.6f, 0.6f);
     print_text1_center_mode_1(
-        (temp_s0 - arg0->column) + 0xF5, arg0->row + 0xE1,
+        (temp_s0 - arg0->column) + leftShift + 0xF5, arg0->row + 0xE1,
         D_800E76CC[gGameModeSubMenuColumn[gPlayerCount - 1][gGameModeMenuColumn[gPlayerCount - 1]]], 0, 0.6f, 0.6f);
 }
 
@@ -7748,6 +7775,20 @@ void func_800A34A8(MenuItem* arg0) {
     s32 temp_s0_3;
     s32 rank;
     s32 test;
+    s32 leftShift;
+    s32 rightShift;
+
+    // @port Keep each tally column centered over its half of the window; the
+    // vanilla columns center them on a 4:3 screen. print_letter culls glyphs
+    // that start outside the vanilla 320 wide area, so clamp on very wide windows.
+    leftShift = get_left_half_center() - 80;
+    rightShift = get_right_half_center() - 240;
+    if (leftShift < -25) {
+        leftShift = -25;
+    }
+    if (rightShift > 24) {
+        rightShift = 24;
+    }
 
     if (arg0->state != 0) {
         if (arg0->state < 9) {
@@ -7759,11 +7800,11 @@ void func_800A34A8(MenuItem* arg0) {
             func_800A3A10(gCharacterIdByGPOverallRank);
         }
         set_text_color(TEXT_BLUE_GREEN_RED_CYCLE_1);
-        print_text_mode_1(arg0->column + 0x19, 0x19 - arg0->row, "driver's points", 0, 0.8f, 0.8f);
+        print_text_mode_1(arg0->column + leftShift + 0x19, 0x19 - arg0->row, "driver's points", 0, 0.8f, 0.8f);
         set_text_color(TEXT_BLUE_GREEN_RED_CYCLE_2);
-        print_text_mode_1(arg0->column + 0x36, 0x28 - arg0->row, "round", 0, 0.7f, 0.7f);
+        print_text_mode_1(arg0->column + leftShift + 0x36, 0x28 - arg0->row, "round", 0, 0.7f, 0.7f);
         convert_number_to_ascii(GetCupCursorPosition() + 1, sp78);
-        print_text_mode_1(arg0->column + 0x61, (0x28 & 0xFFFFFFFF) - arg0->row, &sp78[1], 0, 0.7f, 0.7f);
+        print_text_mode_1(arg0->column + leftShift + 0x61, (0x28 & 0xFFFFFFFF) - arg0->row, &sp78[1], 0, 0.7f, 0.7f);
         for (rank = 0; rank < 4; rank++) {
             test = arg0->state;
             if ((test != 8) && (test != 9)) {
@@ -7789,8 +7830,8 @@ void func_800A34A8(MenuItem* arg0) {
                     var_a0 = 3;
                 }
                 set_text_color(var_a0);
-                func_800A3ADC(arg0, arg0->column + var_v1 + 0x1C, ((rank * 0x10) - arg0->row) + 0x38, sp80[rank], rank,
-                              sp80);
+                func_800A3ADC(arg0, arg0->column + var_v1 + leftShift + 0x1C, ((rank * 0x10) - arg0->row) + 0x38,
+                              sp80[rank], rank, sp80);
             }
         }
         for (rank = 4; rank < NUM_PLAYERS; rank++) {
@@ -7816,16 +7857,17 @@ void func_800A34A8(MenuItem* arg0) {
                     var_a0 = 3;
                 }
                 set_text_color(var_a0);
-                func_800A3ADC(arg0, 0xBE - arg0->column, arg0->row + (rank * 0x10) + 0x5A, sp80[rank], rank, sp80);
+                func_800A3ADC(arg0, (0xBE + rightShift) - arg0->column, arg0->row + (rank * 0x10) + 0x5A, sp80[rank],
+                              rank, sp80);
             }
         }
         set_text_color(TEXT_BLUE_GREEN_RED_CYCLE_2);
         temp_s0_3 = ((get_string_width(gCupNames[GetCupIndex()]) + 8) * 0.6f) / 2;
         print_text1_center_mode_1(
-            (-(s32) (((get_string_width(D_800E76CC[gCCSelection]) + 8) * 0.6f) / 2) - arg0->column) + 0xE6,
+            (-(s32) (((get_string_width(D_800E76CC[gCCSelection]) + 8) * 0.6f) / 2) - arg0->column) + rightShift + 0xE6,
             arg0->row + 0xE1, gCupNames[D_800DC540], 0, 0.6f, 0.6f);
         print_text1_center_mode_1(
-            (temp_s0_3 - arg0->column) + 0xE6, arg0->row + 0xE1,
+            (temp_s0_3 - arg0->column) + rightShift + 0xE6, arg0->row + 0xE1,
             D_800E76CC[gGameModeSubMenuColumn[gPlayerCount - 1][gGameModeMenuColumn[gPlayerCount - 1]]], 0, 0.6f, 0.6f);
     }
 }
@@ -8273,9 +8315,9 @@ static s32 get_pause_menu_column(s32 column) {
 
     screen = &gScreenContexts[gIsGamePaused - 1];
     if ((screen->player == gPlayerOne) || (screen->player == gPlayerThree)) {
-        halfCenter = (OTRGetDimensionFromLeftEdge(0) + (SCREEN_WIDTH / 2)) / 2.0f;
+        halfCenter = get_left_half_center();
     } else {
-        halfCenter = (OTRGetDimensionFromRightEdge(SCREEN_WIDTH) + (SCREEN_WIDTH / 2)) / 2.0f;
+        halfCenter = get_right_half_center();
     }
 
     // The menu items are left-aligned, so center the widest one.

--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -8259,6 +8259,43 @@ void render_pause_menu_time_trials(MenuItem* arg0) {
     }
 }
 
+// @port Center the pause menu text within the pausing player's half of the window in
+// 3/4 player splitscreen. The vanilla columns assume a 4:3 quadrant, so on wider
+// windows the text drifts toward the middle of the screen.
+static s32 get_pause_menu_column(s32 column) {
+    ScreenContext* screen;
+    f32 halfCenter;
+    s32 textWidth;
+
+    if (gScreenModeSelection != SCREEN_MODE_3P_4P_SPLITSCREEN) {
+        return column;
+    }
+
+    screen = &gScreenContexts[gIsGamePaused - 1];
+    if ((screen->player == gPlayerOne) || (screen->player == gPlayerThree)) {
+        halfCenter = (OTRGetDimensionFromLeftEdge(0) + (SCREEN_WIDTH / 2)) / 2.0f;
+    } else {
+        halfCenter = (OTRGetDimensionFromRightEdge(SCREEN_WIDTH) + (SCREEN_WIDTH / 2)) / 2.0f;
+    }
+
+    // The menu items are left-aligned, so center the widest one.
+    textWidth = MAX(get_string_width(gTextPauseButton[CONTINUE_GAME]),
+                    MAX(get_string_width(gTextPauseButton[COURSE_CHANGE]),
+                        get_string_width(gTextPauseButton[DRIVER_CHANGE])));
+    textWidth = textWidth * 0.75f;
+
+    column = halfCenter - (textWidth / 2);
+    // print_letter culls glyphs that fall entirely outside the vanilla 320 wide
+    // area, so keep the text inside it on very wide windows.
+    if (column < 2) {
+        column = 2;
+    }
+    if (column > (SCREEN_WIDTH - 2) - textWidth) {
+        column = (SCREEN_WIDTH - 2) - textWidth;
+    }
+    return column;
+}
+
 void render_pause_menu_versus(MenuItem* arg0) {
     s16 temp_t0;
     s16 temp_v1;
@@ -8268,6 +8305,7 @@ void render_pause_menu_versus(MenuItem* arg0) {
     s32 var_s1;
     s32 leftEdge;
     s32 rightEdge;
+    s32 column;
     Unk_D_800E70A0* temp_s3;
     ScreenContext* temp_v0;
 
@@ -8313,6 +8351,7 @@ void render_pause_menu_versus(MenuItem* arg0) {
     }
 
     temp_s3 = &D_800E8540[(gScreenModeSelection * 4) + (gIsGamePaused - 1)];
+    column = get_pause_menu_column(temp_s3->column);
     for (var_s0 = 0; var_s0 < 4; var_s0++) {
         if (var_s0 > 0) {
             var_s1 = var_s0 + 1;
@@ -8320,7 +8359,7 @@ void render_pause_menu_versus(MenuItem* arg0) {
             var_s1 = var_s0;
         }
         text_rainbow_effect(arg0->state - 0x15, var_s0, TEXT_YELLOW);
-        print_text_mode_1(temp_s3->column - 2, temp_s3->row + (13 * var_s0), gTextPauseButton[var_s1], 0, 0.75f, 0.75f);
+        print_text_mode_1(column - 2, temp_s3->row + (13 * var_s0), gTextPauseButton[var_s1], 0, 0.75f, 0.75f);
     }
 }
 
@@ -8386,6 +8425,7 @@ void render_pause_battle(MenuItem* arg0) {
     s32 var_s1;
     s32 leftEdge;
     s32 rightEdge;
+    s32 column;
     Unk_D_800E70A0* temp_s3;
 
     temp_v0 = &gScreenContexts[gIsGamePaused - 1];
@@ -8430,6 +8470,7 @@ void render_pause_battle(MenuItem* arg0) {
     }
 
     temp_s3 = &D_800E8600[(gScreenModeSelection * 4) + (gIsGamePaused - 1)];
+    column = get_pause_menu_column(temp_s3->column);
     for (var_a1 = 0; var_a1 < 4; var_a1++) {
         if (var_a1 > 0) {
             var_s1 = var_a1 + 1;
@@ -8437,7 +8478,7 @@ void render_pause_battle(MenuItem* arg0) {
             var_s1 = var_a1;
         }
         text_rainbow_effect(arg0->state - 41, var_a1, TEXT_YELLOW);
-        print_text_mode_1(temp_s3->column - 2, temp_s3->row + 13 * var_a1, gTextPauseButton[var_s1], 0, 0.75f, 0.75f);
+        print_text_mode_1(column - 2, temp_s3->row + 13 * var_a1, gTextPauseButton[var_s1], 0, 0.75f, 0.75f);
     }
 }
 
@@ -8479,7 +8520,7 @@ void func_800A54EC(void) {
             break;
     }
     whyTheSequel = D_800F0B50[why];
-    sp50.column = var_v1->column - 8;
+    sp50.column = get_pause_menu_column(var_v1->column) - 8;
     sp50.row = (var_v1->row + ((sp48->state - whyTheSequel) * 0xD)) - 8;
     pause_menu_item_box_cursor(sp48, &sp50);
 }

--- a/src/port/ui/PortMenu.cpp
+++ b/src/port/ui/PortMenu.cpp
@@ -407,7 +407,8 @@ void PortMenu::AddEnhancements() {
         .Options(CheckboxOptions().Tooltip("Press C-Left to look behind you"));
     AddWidget(path, "Fix Visuals", WIDGET_CVAR_CHECKBOX)
         .CVar("gFixVisuals")
-        .Options(CheckboxOptions().Tooltip("Fixes the second last lamp glow in Banshee Boardwalk"));
+        .Options(CheckboxOptions().Tooltip(
+            "Fixes the second last lamp glow in Banshee Boardwalk, and true text centering within quadrants"));
 
     AddRulesets();
 


### PR DESCRIPTION
Fixes #285. Fixes #286.

[445eebe](https://github.com/HarbourMasters/SpaghettiKart/pull/753/commits/445eebe45a45b71d5f7e452092449d56616d27a3)
In 3 and 4 player splitscreen the viewports split at the center of the window, but the pause menu text draws at vanilla 4:3 screen coordinates, so on wide windows it drifts toward the middle of the screen instead of staying over the pausing player's quadrant. This centers the pause menu text and the item box cursor within the pausing player's half of the window at any aspect ratio, in both versus and battle.

Before (No Fix):
<img width="1728" height="1117" alt="Pre-Fix" src="https://github.com/user-attachments/assets/b7389bf4-f801-4b2d-9e4e-551823db7960" />

After (With Fix):
<img width="1728" height="1117" alt="With Fix" src="https://github.com/user-attachments/assets/5759ea2d-b988-4d83-b0a6-73ee867108fd" />

[567d535](https://github.com/HarbourMasters/SpaghettiKart/pull/753/commits/567d5355a1942d0b9d02453456b291b8c66eaca6)
The Grand Prix results and driver's points screens have the same drift over their four viewports, so the second commit applies the same correction there. Those two screens keep the vanilla placement within each half of the window rather than exact centering, since that is how the N64 lays them out. At 4:3 every offset is zero, so the stock layout is untouched.

The shifts use the same OTRGetDimensionFromLeftEdge/RightEdge helpers the pause background box already uses, and they are clamped so no glyph gets culled on very wide windows (print_letter skips glyphs that start outside the vanilla 320 wide area).

Before (No Fix):
<img width="1728" height="1117" alt="Pre-Fix GP" src="https://github.com/user-attachments/assets/8739b10e-f1da-4420-988d-2873640a43d9" />

After (With Fix):
<img width="1728" height="1117" alt="With Fix GP" src="https://github.com/user-attachments/assets/ae7eaafa-c8a7-42d0-aad2-eaf39e162ef9" />

[d60e62d](https://github.com/HarbourMasters/SpaghettiKart/pull/753/commits/d60e62d9ce8d8cd99b84e302141e73c973575947)
The third commit covers the last spot with this drift (the cup and course names placed in the fourth viewport in 3 player races).

Before (No Fix):
<img width="1728" height="1117" alt="Screenshot 2026-08-17 at 8 18 30 PM" src="https://github.com/user-attachments/assets/542092ac-64df-43a2-818b-085c65279ca6" />

After (With Fix):
<img width="1728" height="1117" alt="After" src="https://github.com/user-attachments/assets/d00520d0-13cc-41a6-9312-0e13319ccb6a" />

It also adds full true centering within quadrants under the existing Fix Visuals toggle: with it on, the banner and the results and points columns center exactly over their half of the window instead of keeping the slight vanilla lean toward the middle. The toggle off state and 4:3 stay stock, and the multiplayer pause menu is unaffected by the toggle since vanilla already centers it (and is fixed with commit [445eebe](https://github.com/HarbourMasters/SpaghettiKart/pull/753/commits/445eebe45a45b71d5f7e452092449d56616d27a3)), so there is nothing to choose between. The Fix Visuals tooltip gains a mention of the centering, which may need a trivial merge with #750's tooltip edit depending on which lands first.

After (With Fix + Fix Visuals Toggle On):
<img width="1728" height="1117" alt="Screenshot 2026-08-17 at 8 20 57 PM" src="https://github.com/user-attachments/assets/38b45602-a7cb-4c1b-b8ac-f7d0e4ccf2d1" />

Verified in 4 player battle and versus pausing as all four players, and through a 1P Grand Prix race on a wide window. Verified the third commit in 3 player versus with Fix Visuals on and off, and through a 2 player Grand Prix's results and points screens, all on a wide window.
