### PR TITLE
Fix: Audio stutter/slow-down when game ticks lag or jitter

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -493,26 +493,35 @@ void GameEngine::HandleAudioThread() {
         }
         std::unique_lock<std::mutex> Lock(audio.mutex);
 
-        int samples_left = AudioPlayerBuffered();
-        u32 num_audio_samples = samples_left < AudioPlayerGetDesiredBuffered() ? SAMPLES_HIGH : SAMPLES_LOW;
+        // Top the player buffer back up with at most three batches per tick so
+        // a game tick rate below 30 cannot starve the speakers; the N64 ran its
+        // audio thread at vblank rate, independent of the game thread's rate.
+        for (int batch = 0; batch < 3; batch++) {
+            int samples_left = AudioPlayerBuffered();
+            u32 num_audio_samples = samples_left < AudioPlayerGetDesiredBuffered() ? SAMPLES_HIGH : SAMPLES_LOW;
 
-        s16 nas_buffer[SAMPLES_PER_FRAME] = { 0 };
-        f32 hmas_buffer[SAMPLES_PER_FRAME] = { 0 };
-        s16 mix_buffer[SAMPLES_PER_FRAME] = { 0 };
+            s16 nas_buffer[SAMPLES_PER_FRAME] = { 0 };
+            f32 hmas_buffer[SAMPLES_PER_FRAME] = { 0 };
+            s16 mix_buffer[SAMPLES_PER_FRAME] = { 0 };
 
-        for (size_t i = 0; i < NUM_AUDIO_CHANNELS; i++) {
-            create_next_audio_buffer(nas_buffer + i * (num_audio_samples * 2), num_audio_samples);
+            for (size_t i = 0; i < NUM_AUDIO_CHANNELS; i++) {
+                create_next_audio_buffer(nas_buffer + i * (num_audio_samples * 2), num_audio_samples);
+            }
+
+            GameEngine::Instance->gHMAS->CreateBuffer((u8*)hmas_buffer, 4 * num_audio_samples * sizeof(float));
+
+            float master_vol = CVarGetFloat("gGameMasterVolume", 1.0f);
+
+            for (size_t i = 0; i < SAMPLES_PER_FRAME; i++) {
+                mix_buffer[i] = nas_buffer[i] + ((int16_t)(hmas_buffer[i] * 32767.0f) * master_vol);
+            }
+
+            AudioPlayerPlayFrame((u8*) mix_buffer, 2 * num_audio_samples * 4);
+
+            if (AudioPlayerBuffered() >= AudioPlayerGetDesiredBuffered()) {
+                break;
+            }
         }
-
-        GameEngine::Instance->gHMAS->CreateBuffer((u8*)hmas_buffer, 4 * num_audio_samples * sizeof(float));
-
-        float master_vol = CVarGetFloat("gGameMasterVolume", 1.0f);
-
-        for (size_t i = 0; i < SAMPLES_PER_FRAME; i++) {
-            mix_buffer[i] = nas_buffer[i] + ((int16_t)(hmas_buffer[i] * 32767.0f) * master_vol);
-        }
-
-        AudioPlayerPlayFrame((u8*) mix_buffer, 2 * num_audio_samples * 4);
 
         audio.processing = false;
         audio.cv_from_thread.notify_one();


### PR DESCRIPTION
When the game logic drops below 30 ticks per second (3/4P splitscreen on heavier courses, or an unfocused window macOS throttles), audio production falls behind the output rate: the music tempo drops and playback stutters. Frame interpolation keeps the picture smooth, so the tick drop is only audible.

The audio thread produces exactly two audio frames per game tick, and the 26800 Hz output drains exactly that at 30 ticks per second, with zero slack. At 27 ticks the player buffer pins at zero and the sequencer falls behind real time (verified with an instrumented build). The same zero slack causes momentary dropouts at full speed when a tick runs late.

The fix repeats the existing batch while the player buffer is below its existing target, capped at three per tick. At a healthy 30 ticks the extra batches never run. The N64 ran audio at vblank rate independent of the game thread, so music holding tempo under lag is the original behavior.

Verified on macOS: instrumented A/B (27 ticks now produces 27700 samples per second against the 26800 drain with the buffer at target, was 24200 and pinned at zero), 3P and 4P races by ear, the unfocused window case, and an unchanged 1P Grand Prix.
