### PR TITLE
Fix: first-run setup exits silently on minimal Linux desktops

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -345,7 +345,13 @@ int GameEngine::ShowYesNoBox(const char* title, const char* box) {
     boxData.message = box;
     boxData.title = title;
     boxData.buttons = buttons;
-    SDL_ShowMessageBox(&boxData, &ret);
+    if (SDL_ShowMessageBox(&boxData, &ret) < 0) {
+        // Minimal desktops (Batocera and similar) cannot show SDL dialogs. Take the default
+        // button so first-run setup can continue instead of exiting with no message.
+        SPDLOG_WARN("Could not show the \"{}\" dialog ({}). Answering Yes. Message was: {}", title, SDL_GetError(),
+                    box);
+        ret = IDYES;
+    }
 #endif
     return ret;
 }

--- a/src/port/GameExtractor.cpp
+++ b/src/port/GameExtractor.cpp
@@ -5,7 +5,9 @@
 #pragma comment(lib, "Shlwapi.lib")
 #endif
 #include "GameExtractor.h"
+#include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <unordered_map>
 
 #include <fstream>
@@ -119,9 +121,37 @@ bool GameExtractor::SelectGameFromUI() {
 }
 
 void GameExtractor::GetRoms(std::vector<std::string>& roms) {
+    // Also look next to the executable and in the data folder (where mk64.o2r is written), so a
+    // launcher that starts the game from another working directory still finds the ROM.
+    std::vector<std::string> candidates = { ".", Ship::Context::GetAppBundlePath(),
+                                            Ship::Context::GetAppDirectoryPath() };
+#ifdef __linux__
+    // An AppImage runs from a temporary mount, so the executable's folder is not where the user
+    // put the game. The AppImage runtime exports the image's own path.
+    if (const char* appImage = std::getenv("APPIMAGE")) {
+        candidates.push_back(std::filesystem::path(appImage).parent_path().string());
+    }
+#endif
+    std::vector<std::filesystem::path> scanned;
+
+    for (const auto& directory : candidates) {
+        std::error_code ec;
+        const auto canonical = std::filesystem::weakly_canonical(directory, ec);
+        if (ec || std::find(scanned.begin(), scanned.end(), canonical) != scanned.end()) {
+            continue;
+        }
+        scanned.push_back(canonical);
+        ScanForRoms(directory, roms);
+    }
+}
+
+void GameExtractor::ScanForRoms(const std::string& directory, std::vector<std::string>& roms) {
 #ifdef _WIN32
     WIN32_FIND_DATAA ffd;
-    HANDLE h = FindFirstFileA(".\\*", &ffd);
+    HANDLE h = FindFirstFileA((directory + "\\*").c_str(), &ffd);
+    if (h == INVALID_HANDLE_VALUE) {
+        return;
+    }
 
     do {
         if (!(ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
@@ -129,15 +159,13 @@ void GameExtractor::GetRoms(std::vector<std::string>& roms) {
 
             // Check for any standard N64 rom file extensions.
             if ((strcmp(ext, ".z64") == 0))
-                roms.push_back(ffd.cFileName);
+                roms.push_back(directory + "\\" + ffd.cFileName);
         }
     } while (FindNextFileA(h, &ffd) != 0);
-    // if (h != nullptr) {
-    //    CloseHandle(h);
-    //}
+    FindClose(h);
 #elif unix
     // Open the directory of the app.
-    DIR* d = opendir(".");
+    DIR* d = opendir(directory.c_str());
     struct dirent* dir;
 
     if (d != NULL) {
@@ -145,7 +173,7 @@ void GameExtractor::GetRoms(std::vector<std::string>& roms) {
         while ((dir = readdir(d)) != NULL) {
             struct stat path;
 
-            auto fullPath = std::filesystem::path(".") / dir->d_name;
+            auto fullPath = std::filesystem::path(directory) / dir->d_name;
             auto fullPathString = fullPath.string();
             const char* fullPathCStr = fullPathString.c_str();
 
@@ -160,10 +188,11 @@ void GameExtractor::GetRoms(std::vector<std::string>& roms) {
                 }
             }
         }
+        closedir(d);
     }
-    closedir(d);
 #else
-    for (const auto& file : std::filesystem::directory_iterator(".")) {
+    std::error_code ec;
+    for (const auto& file : std::filesystem::directory_iterator(directory, ec)) {
         if (file.is_directory())
             continue;
         if (file.path().extension() == ".z64") {

--- a/src/port/GameExtractor.cpp
+++ b/src/port/GameExtractor.cpp
@@ -192,7 +192,11 @@ void GameExtractor::ScanForRoms(const std::string& directory, std::vector<std::s
     }
 #else
     std::error_code ec;
-    for (const auto& file : std::filesystem::directory_iterator(directory, ec)) {
+    std::filesystem::directory_iterator entries(directory, ec);
+    if (ec) {
+        return;
+    }
+    for (const auto& file : entries) {
         if (file.is_directory())
             continue;
         if (file.path().extension() == ".z64") {

--- a/src/port/GameExtractor.h
+++ b/src/port/GameExtractor.h
@@ -13,6 +13,8 @@ public:
     void GetRoms(std::vector<std::string>& roms);
     bool GenerateOTR() const;
 private:
+    static void ScanForRoms(const std::string& directory, std::vector<std::string>& roms);
+
     fs::path mGamePath;
     std::vector<uint8_t> mGameData;
 };


### PR DESCRIPTION
[5a0e139](https://github.com/HarbourMasters/SpaghettiKart/pull/755/commits/5a0e139e1)

From the Batocera thread on Discord (RonBurgundy87, coco was helping). On that system SDL cannot show a message box, so the "No O2R files found. Generate one now?" prompt fails, ShowYesNoBox returns an unset value, and the game exits with nothing in the log. This checks the SDL_ShowMessageBox result and answers with the default button (Yes) when the dialog cannot be shown, logging the question and SDL's error, so first-run extraction runs from a ROM in the folder with no dialogs involved. Copying over a Windows-generated mk64.o2r is what got him running, which confirmed everything past that prompt was fine.

[0fec9ef](https://github.com/HarbourMasters/SpaghettiKart/pull/755/commits/0fec9efff)

GetRoms only scanned the working directory, which is why he also needed a wrapper script that cds into the folder first. This scans the executable folder and the data folder too, like Ghostship does, and on Linux the folder holding the AppImage (the executable folder is a temporary mount there). Duplicates are skipped, and the Windows branch now checks the find handle and closes it with FindClose. Happy to drop this commit if you want to keep the scope to the first one.

Verified on macOS: with a test patch that makes every SDL dialog fail, the warning is logged, extraction runs, and the game boots; the stock build still shows the dialog and Yes runs extraction; and with the ROM only in the data folder, or only beside a fake AppImage path with the Linux guard lifted, launched from an empty directory, it is found and extraction runs. The opendir and Windows branches are compiled by CI only, and I have not run this on a real AppImage.
