### PR TITLE
Fix audio_reset_session_eu

### DIFF
--- a/src/audio/GameAudio.h
+++ b/src/audio/GameAudio.h
@@ -9,4 +9,5 @@ static struct {
     std::mutex mutex;
     bool running;
     bool processing;
+    bool paused;
 } audio;

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -12,6 +12,7 @@
 #include "audio/seqplayer.h"
 #include "audio/data.h"
 #include "audio/port_eu.h"
+#include "port/Engine.h"
 #include "code_800029B0.h"
 #include "code_80005FD0.h"
 #include "menu_items.h"
@@ -183,11 +184,11 @@ void audio_reset_session_eu(s32 presetId) {
      * So, the code that 'does the work' must run *right now!* instead of 'later'
      * Taken from audio_shut_down_and_reset_step() case 5:
      **/
+    GameEngine_LockAudio();
     for (size_t i = 0; i < SEQUENCE_PLAYERS; i++) {
         sequence_player_disable(&gSequencePlayers[i]);
     }
-    gAudioResetFadeOutFramesLeft = 4;
-    gAudioResetStatus--;
+    GameEngine_UnlockAudio();
 
     // Reset HMAS audio
     if(HMAS_IsPlaying(HMAS_MUSIC)){

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -176,10 +176,13 @@ void audio_reset_session_eu(s32 presetId) {
     //    osRecvMesg(D_800EA3B4, &mesg, OS_MESG_BLOCK);
     // }
 
-    // The above code is for a threaded asynchronous system
-    // libultraship uses single-threaded Recv/Send which means values do not
-    // get set at the correct times:
-    // So, the code that 'does the work' must run *right now!* instead of 'later'
+    /** 
+     * The above code is for a threaded asynchronous system
+     * libultraship uses single-threaded Recv/Send which means values do not
+     * get set at the correct times:
+     * So, the code that 'does the work' must run *right now!* instead of 'later'
+     * Taken from audio_shut_down_and_reset_step() case 5:
+     **/
     for (size_t i = 0; i < SEQUENCE_PLAYERS; i++) {
         sequence_player_disable(&gSequencePlayers[i]);
     }

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -176,14 +176,20 @@ void audio_reset_session_eu(s32 presetId) {
     // }
 
     // The above code is for a threaded asynchronous system
-    // libultraship does not work with that kind of system as values are not set
-    // at the correct times:
+    // libultraship uses single-threaded Recv/Send which means values do not
+    // get set at the correct times:
     // So, the code that 'does the work' must run *right now!* instead of 'later'
     for (size_t i = 0; i < SEQUENCE_PLAYERS; i++) {
         sequence_player_disable(&gSequencePlayers[i]);
     }
     gAudioResetFadeOutFramesLeft = 4;
     gAudioResetStatus--;
+
+    // Reset HMAS audio
+    if(HMAS_IsPlaying(HMAS_MUSIC)){
+        HMAS_AddEffect(HMAS_MUSIC, HMAS_EFFECT_VOLUME, HMAS_LINEAR, 10, 0);
+        HMAS_AddEffect(HMAS_MUSIC, HMAS_EFFECT_STOP,   HMAS_INSTANT, 1, 0);
+    }
 }
 
 f32 func_800C1480(u8 bank, u8 soundId) {

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -9,6 +9,7 @@
 #include "audio/external.h"
 #include "audio/heap.h"
 #include "audio/load.h"
+#include "audio/seqplayer.h"
 #include "audio/data.h"
 #include "audio/port_eu.h"
 #include "code_800029B0.h"

--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -7,6 +7,7 @@
 #include "math_util_2.h"
 #include <sounds.h>
 #include "audio/external.h"
+#include "audio/heap.h"
 #include "audio/load.h"
 #include "audio/data.h"
 #include "audio/port_eu.h"
@@ -159,14 +160,30 @@ char external_unused_string_eu_03[] = "SE FADE OUT TIME %d\n";
 void func_800C13F0(void) {
 }
 
-void audio_reset_session_eu(OSMesg presetId) {
-    OSMesg mesg;
-    osRecvMesg(D_800EA3B4, &mesg, 0);
-    osSendMesg(D_800EA3B0, presetId, 0);
-    osRecvMesg(D_800EA3B4, &mesg, 1);
-    if (mesg.data32 != presetId.data32) {
-        osRecvMesg(D_800EA3B4, &mesg, 1);
+/**
+ * Fade out sequence players
+ */
+void audio_reset_session_eu(s32 presetId) {
+    // OSMesg mesg;
+    // osRecvMesg(D_800EA3B4, &mesg, OS_MESG_NOBLOCK);
+    
+    // osSendMesg(D_800EA3B0, OS_MESG_32(presetId), OS_MESG_NOBLOCK);
+
+    // osRecvMesg(D_800EA3B4, &mesg, OS_MESG_BLOCK);
+    
+    // if (mesg.data32 != presetId) {
+    //    osRecvMesg(D_800EA3B4, &mesg, OS_MESG_BLOCK);
+    // }
+
+    // The above code is for a threaded asynchronous system
+    // libultraship does not work with that kind of system as values are not set
+    // at the correct times:
+    // So, the code that 'does the work' must run *right now!* instead of 'later'
+    for (size_t i = 0; i < SEQUENCE_PLAYERS; i++) {
+        sequence_player_disable(&gSequencePlayers[i]);
     }
+    gAudioResetFadeOutFramesLeft = 4;
+    gAudioResetStatus--;
 }
 
 f32 func_800C1480(u8 bank, u8 soundId) {
@@ -932,7 +949,7 @@ void func_800C2A2C(u32 cmd) {
             seqId = cmd & 0xFF;
             subArgs = (cmd & 0xFF00) >> 8;
             D_800EA1C0 = subArgs;
-            //audio_reset_session_eu((void*) seqId);
+            audio_reset_session_eu(seqId);
             D_800EA1F4[0] = seqId;
             func_800CBBE8(0x46020000, subArgs);
             func_800C5C40();
@@ -2603,6 +2620,8 @@ void func_800C76C0(u8 playerId) {
                             break;
                         case 2: /* switch 2 */
                             if ((D_800EA0EC[0] == 1) && (D_800EA0EC[1] == 1) && (D_800EA0EC[2] == 1)) {
+                                func_800C3448(0x100100FF); // Added: Reset sound in 3/4P so old music does not play over new music
+                                func_800C3448(0x110100FF); // Added: Reset sound in 3/4P so old music does not play over new music
                                 func_800C5278(5U);
                                 func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0x80, 0x26));
                                 play_sequence2(MUSIC_SEQ_VS_BATTLE_RESULTS);
@@ -2614,6 +2633,8 @@ void func_800C76C0(u8 playerId) {
                         case 3: /* switch 2 */
                             if ((D_800EA0EC[0] == 1) && (D_800EA0EC[1] == 1) && (D_800EA0EC[2] == 1) &&
                                 (D_800EA0EC[3] == 1)) {
+                                func_800C3448(0x100100FF); // Added: Reset sound in 3/4P so old music does not play over new music
+                                func_800C3448(0x110100FF); // Added: Reset sound in 3/4P so old music does not play over new music
                                 func_800C5278(5U);
                                 func_800C9018(playerId, SOUND_ARG_LOAD(0x01, 0x00, 0x80, 0x26));
                                 play_sequence2(MUSIC_SEQ_VS_BATTLE_RESULTS);

--- a/src/audio/external.h
+++ b/src/audio/external.h
@@ -201,7 +201,7 @@ typedef struct {
 void func_800C94A4(u8);
 void func_800CADD0(u8, f32);
 void func_800C13F0(void);
-void audio_reset_session_eu(OSMesg);
+void audio_reset_session_eu(s32);
 f32 func_800C1480(u8, u8);
 s8 func_800C15D0(u8, u8, u8);
 s8 func_800C16E8(f32, f32, u8);

--- a/src/audio/heap.c
+++ b/src/audio/heap.c
@@ -599,9 +599,9 @@ void audio_reset_session(void) {
     s32 var_s1;
     s32 var_s5;
     s32 temp;
-    s32 totalMem;
-    s32 temporaryMem;
-    s32 persistentMem;
+    u32 totalMem;
+    u32 temporaryMem;
+    u32 persistentMem;
     s16* mem;
     struct SynthesisReverb* reverb;
     struct ReverbSettingsEU* reverbSettings;

--- a/src/audio/port_eu.c
+++ b/src/audio/port_eu.c
@@ -58,14 +58,14 @@ void create_next_audio_buffer(s16* samples, u32 num_samples) {
     gCurrAudioFrameDmaCount = 0;
 
     if (osRecvMesg(D_800EA3B0, &specId, 0) != -1) {
-        gAudioResetPresetIdToLoad = specId.data8;
+        gAudioResetPresetIdToLoad = (u8)specId.data32;
         gAudioResetStatus = 5;
     }
 
     if (gAudioResetStatus != 0) {
         if (audio_shut_down_and_reset_step() == 0) {
             if (gAudioResetStatus == 0) {
-                osSendMesg(D_800EA3B4, OS_MESG_8(gAudioResetPresetIdToLoad), OS_MESG_NOBLOCK);
+                osSendMesg(D_800EA3B4, OS_MESG_32(gAudioResetPresetIdToLoad), OS_MESG_NOBLOCK);
             }
             return;
         }
@@ -96,13 +96,8 @@ struct SPTask* create_next_audio_frame_task(void) {
     if ((gAudioFrameCount % gAudioBufferParameters.presetUnk4) != 0) {
         return NULL;
     }
-#ifdef TARGET_N64
-    osSendMesg(D_800EA3A8, (OSMesg) gAudioFrameCount, OS_MESG_NOBLOCK);
-#else
-    OSMesg audioMesg;
-    audioMesg.ptr = (void*) gAudioFrameCount;
-    osSendMesg(D_800EA3A8, audioMesg, OS_MESG_NOBLOCK);
-#endif
+
+    osSendMesg(D_800EA3A8, OS_MESG_32(gAudioFrameCount), OS_MESG_NOBLOCK);
 
     gAudioTaskIndex ^= 1;
     gCurrAiBufferIndex++;
@@ -133,13 +128,13 @@ struct SPTask* create_next_audio_frame_task(void) {
     gCurrAudioFrameDmaCount = 0;
     decrease_sample_dma_ttls();
     if (osRecvMesg(D_800EA3B0, &sp58, 0) != -1) {
-        // gAudioResetPresetIdToLoad = (u8) (u32) sp58;
+        gAudioResetPresetIdToLoad = (u8) sp58.data32;
         gAudioResetStatus = 5;
     }
     if (gAudioResetStatus != 0) {
         if (audio_shut_down_and_reset_step() == 0) {
             if (gAudioResetStatus == 0) {
-                osSendMesg(D_800EA3B4, sp58, OS_MESG_NOBLOCK);
+                osSendMesg(D_800EA3B4, OS_MESG_32(gAudioResetPresetIdToLoad), OS_MESG_NOBLOCK);
             }
             return NULL;
         }

--- a/src/engine/cameras/TourCamera.cpp
+++ b/src/engine/cameras/TourCamera.cpp
@@ -57,6 +57,10 @@ void TourCamera::Stop() {
     printf("[TourCamera] End of Track Tour\n");
     gTourComplete = true;
     func_800CA330(0x19); // Reset audio
+    if(HMAS_IsPlaying(HMAS_MUSIC)){
+        HMAS_AddEffect(HMAS_MUSIC, HMAS_EFFECT_VOLUME, HMAS_LINEAR, 10, 0);
+        HMAS_AddEffect(HMAS_MUSIC, HMAS_EFFECT_STOP,   HMAS_INSTANT, 1, 0);
+    }
 
     gScreenContexts[0].pendingCamera = &cameras[0];
     bActive = false;

--- a/src/engine/cameras/TourCamera.cpp
+++ b/src/engine/cameras/TourCamera.cpp
@@ -56,7 +56,7 @@ void TourCamera::NextShot() {
 void TourCamera::Stop() {
     printf("[TourCamera] End of Track Tour\n");
     gTourComplete = true;
-    CM_ResetAudio();
+    func_800CA330(0x19); // Reset audio
 
     gScreenContexts[0].pendingCamera = &cameras[0];
     bActive = false;

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -480,21 +480,21 @@ void GameEngine::ProcessGfxCommands(Gfx* pool) {
 
 // Audio
 void GameEngine::HandleAudioThread() {
-    while (audio.running) {
-        {
-            std::unique_lock<std::mutex> Lock(audio.mutex);
-            while (!audio.processing && audio.running) {
-                audio.cv_to_thread.wait(Lock);
-            }
-
-            if (!audio.running) {
-                break;
-            }
-        }
+    while (true) {
         std::unique_lock<std::mutex> Lock(audio.mutex);
+
+        audio.cv_to_thread.wait(Lock, [&] {
+            return !audio.running || (audio.processing && !audio.paused);
+        });
+
+        if (!audio.running) {
+            break;
+        }
 
         int samples_left = AudioPlayerBuffered();
         u32 num_audio_samples = samples_left < AudioPlayerGetDesiredBuffered() ? SAMPLES_HIGH : SAMPLES_LOW;
+        
+        Lock.unlock();
 
         s16 nas_buffer[SAMPLES_PER_FRAME] = { 0 };
         f32 hmas_buffer[SAMPLES_PER_FRAME] = { 0 };
@@ -514,11 +514,13 @@ void GameEngine::HandleAudioThread() {
 
         AudioPlayerPlayFrame((u8*) mix_buffer, 2 * num_audio_samples * 4);
 
+        {
+        std::lock_guard<std::mutex> Lock(audio.mutex);
         audio.processing = false;
-        audio.cv_from_thread.notify_one();
+        }
+        audio.cv_from_thread.notify_all();
     }
 }
-
 void GameEngine::StartAudioFrame() {
     {
         std::unique_lock<std::mutex> Lock(audio.mutex);
@@ -531,9 +533,9 @@ void GameEngine::StartAudioFrame() {
 void GameEngine::EndAudioFrame() {
     {
         std::unique_lock<std::mutex> Lock(audio.mutex);
-        while (audio.processing) {
-            audio.cv_from_thread.wait(Lock);
-        }
+        audio.cv_from_thread.wait(Lock, [&] {
+            return !audio.processing;
+        });
     }
 }
 
@@ -580,6 +582,26 @@ void GameEngine::AudioExit() {
 
     // Wait until the audio thread quit
     audio.thread.join();
+}
+
+void GameEngine::AudioLock() {
+    std::unique_lock lock(audio.mutex);
+
+    audio.paused = true;
+
+    // Wait for any audio frame currently executing to finish.
+    audio.cv_from_thread.wait(lock, [&] {
+        return !audio.processing;
+    });
+}
+
+void GameEngine::AudioUnlock() {
+    {
+        std::lock_guard lock(audio.mutex);
+        audio.paused = false;
+    }
+
+    audio.cv_to_thread.notify_one();
 }
 
 uint8_t GameEngine::GetBankIdByName(const std::string& name) {
@@ -740,6 +762,16 @@ extern "C" int32_t GameEngine_ResourceGetTexTypeByName(const char* name) {
 
     SPDLOG_ERROR("Given texture path {} is a non-existent resource", name);
     return -1;
+}
+
+extern "C" void GameEngine_LockAudio() {
+    auto engine = GameEngine::Instance;
+    engine->AudioLock();
+}
+
+extern "C" void GameEngine_UnlockAudio() {
+    auto engine = GameEngine::Instance;
+    engine->AudioUnlock();
 }
 
 // struct TimedEntry {

--- a/src/port/Engine.h
+++ b/src/port/Engine.h
@@ -66,7 +66,8 @@ class GameEngine {
     static void StartAudioFrame();
     static void EndAudioFrame();
     static void AudioExit();
-
+    void AudioLock();
+    void AudioUnlock();
 
 
     static uint32_t GetInterpolationFPS();
@@ -110,6 +111,8 @@ struct AudioSequenceData* GameEngine_LoadSequence(uint8_t seqId);
 uint32_t GameEngine_GetSequenceCount();
 uint8_t GameEngine_IsSequenceLoaded(uint8_t seqId);
 void GameEngine_UnloadSequence(uint8_t seqId);
+void GameEngine_LockAudio();
+void GameEngine_UnlockAudio();
 // bool GameEngine_OTRSigCheck(char* imgData); -> align_asset_macro.h
 float OTRGetAspectRatio(void);
 float OTRGetDimensionFromLeftEdge(float v);

--- a/src/port/Game.cpp
+++ b/src/port/Game.cpp
@@ -903,19 +903,6 @@ void* GetBattleCup(void) {
 void CM_RunGarbageCollector(void) {
     RunGarbageCollector();
 }
-
-void CM_ResetAudio(void) {
-    if(HMAS_IsPlaying(HMAS_MUSIC)){
-        HMAS_AddEffect(HMAS_MUSIC, HMAS_EFFECT_VOLUME, HMAS_LINEAR, 10, 0);
-        HMAS_AddEffect(HMAS_MUSIC, HMAS_EFFECT_STOP,   HMAS_INSTANT, 1, 0);
-    }
-
-    // Fade out music for all sequences and music player indexes 0, and 1
-    for (size_t soundId = 0; soundId < MUSIC_SEQ_MAX; soundId++) {
-        func_800C3448(0x10100000 | soundId);
-        func_800C3448(0x11100000 | soundId);
-    }
-}
 }
 
 static std::atomic<bool> sResetRequested{ false };
@@ -944,8 +931,6 @@ static void ApplyPendingReset() {
     SetMarioRaceway();
     memset(&gGameModeMenuColumn, 0, sizeof(s8) * NUM_ROWS_GAME_MODE_MENU);
     memset(&gGameModeSubMenuColumn, 0, sizeof(s8) * NUM_COLUMN_GAME_MODE_SUB_MENU * NUM_ROWS_GAME_MODE_SUB_MENU);
-
-    CM_ResetAudio();
 
     // Close the editor.
     if (gEditor.IsEnabled()) {

--- a/src/port/Game.h
+++ b/src/port/Game.h
@@ -230,7 +230,6 @@ void* GetBattleCup(void);
 void* GetCup();
 
 void CM_RunGarbageCollector(void);
-void CM_ResetAudio(void);
 
 NORETURN void CM_ThrowRuntimeError(const char* fmt, ...)
 #if defined(__GNUC__) || defined(__clang__)

--- a/src/port/ui/Tools.cpp
+++ b/src/port/ui/Tools.cpp
@@ -156,7 +156,7 @@ namespace TrackEditor {
                     printf("[Tools.cpp] Failed load scenefile, TrackInfo nullptr\n");
                 }
             } else {
-                CM_ResetAudio();
+                func_800CA330(0x19); // Reset audio
                 CVarSetInteger("gFreecam", true);
                 CM_SetFreeCamera(true);
             }

--- a/src/port/ui/Tools.cpp
+++ b/src/port/ui/Tools.cpp
@@ -157,6 +157,10 @@ namespace TrackEditor {
                 }
             } else {
                 func_800CA330(0x19); // Reset audio
+                if(HMAS_IsPlaying(HMAS_MUSIC)){
+                    HMAS_AddEffect(HMAS_MUSIC, HMAS_EFFECT_VOLUME, HMAS_LINEAR, 10, 0);
+                    HMAS_AddEffect(HMAS_MUSIC, HMAS_EFFECT_STOP,   HMAS_INSTANT, 1, 0);
+                }
                 CVarSetInteger("gFreecam", true);
                 CM_SetFreeCamera(true);
             }

--- a/src/render_player.c
+++ b/src/render_player.c
@@ -1603,7 +1603,7 @@ void render_player(Player* player, s8 playerId, s8 screenId) {
     UNUSED s32 pad[2];
     s32 temp_t1;
     s32 var_v1;
-    OSMesg* sp34;
+    OSMesg mesg;
 
     update_wheel_palette(player, playerId, screenId, D_801651D0[screenId][playerId]);
     if (!(player->unk_002 & (UNK_002_UNKNOWN_0x4 << (screenId * 4)))) {
@@ -1628,7 +1628,7 @@ void render_player(Player* player, s8 playerId, s8 screenId) {
     } else {
         render_ghost(player, playerId, screenId, var_v1);
     }
-    osRecvMesg(&gDmaMesgQueue, (OSMesg*) &sp34, OS_MESG_BLOCK);
+    osRecvMesg(&gDmaMesgQueue, &mesg, OS_MESG_BLOCK);
     if ((temp_t1 == (player->unk_002 & temp_t1)) && (player->surfaceType == ICE) && ((player->kartProps & LAKITU_RETRIEVAL) != LAKITU_RETRIEVAL) &&
         (player->collision.surfaceDistance[2] <= 30.0f)) {
         render_player_ice_reflection(player, playerId, screenId, var_v1);


### PR DESCRIPTION
This PR allows audio to be reset akin to the original systems. It removes the hack-arounds for resetting audio.

osRecvMesg/osSendMesg are asynchronous functions but libultraship does not have threading; it's synchronous.

Therefore, the actual audio fading logic needs to be ran right away and not delayed like how the original system did it.

* Fixes 3/4P battle music (resets audio for the results screen)
* Fixes several inaccuracies as well.
* Removes CM_ResetAudio as its replaced by audio_reset_session_eu

Credits to Quarrel for finding the reset for 3/4P battle and researching the issue.
https://github.com/HarbourMasters/SpaghettiKart/pull/752